### PR TITLE
Studio: UTM analytics dashboard (#196)

### DIFF
--- a/analytics/aggregations.py
+++ b/analytics/aggregations.py
@@ -1,0 +1,553 @@
+"""On-demand SQL helpers for the Studio UTM Analytics dashboard (#196).
+
+All metrics on the UTM Analytics surface go through this module so the
+three views (`utm_dashboard`, `utm_campaign_detail`, `utm_link_detail`)
+share logic and can be unit-tested in isolation.
+
+Performance: aggregate queries with `.values().annotate(Count(...))`
+over indexed columns (`CampaignVisit.utm_campaign`, `CampaignVisit.ts`,
+`UserAttribution.first_touch_utm_campaign`,
+`UserAttribution.first_touch_ts`, `ConversionAttribution.created_at`,
+`ConversionAttribution.first_touch_utm_campaign`) keep us well under
+100ms for low-thousand-row date windows. If any single rollup grows past
+~500ms in production, replace it with a precomputed daily rollup table
+written by a `compute_utm_rollups` management command — TODO until that
+day comes.
+
+The helpers handle the case where ``ConversionAttribution`` is absent
+(``has_conversion_data`` returns False before #195 was merged) by
+returning empty querysets / 0 / Decimal('0'). The dashboard hides MRR
+and Paid columns in that case.
+"""
+
+from datetime import datetime, time, timedelta
+from decimal import Decimal
+
+from django.db.models import Count
+from django.utils import timezone
+
+from analytics.models import CampaignVisit, UserAttribution
+
+# Module-top import of ConversionAttribution. The `analytics` app does not
+# formally depend on `payments`, so we wrap the import in a try/except so
+# this module stays importable even if `payments` is uninstalled. The
+# `_conversion_model()` and `has_conversion_data()` helpers below check
+# this binding so the dashboard degrades gracefully when the model is
+# absent (the "ship-before-#195" stage).
+try:
+    from payments.models import ConversionAttribution as _ConversionAttribution
+except ImportError:  # pragma: no cover — payments is always installed today
+    _ConversionAttribution = None
+
+
+def has_conversion_data():
+    """Whether the ConversionAttribution model is importable.
+
+    Returns False before payments issue #195 has shipped — used by the
+    dashboard to hide the Paid Conversions and MRR columns + KPI cards.
+    Today this returns True (the model exists), but we keep the check
+    behind a function so the dashboard degrades gracefully if the model
+    ever gets removed.
+    """
+    return _ConversionAttribution is not None
+
+
+def _conversion_model():
+    """Return the ``ConversionAttribution`` model class, or None if absent."""
+    return _ConversionAttribution
+
+
+# ---------------------------------------------------------------------------
+# Date window helpers
+# ---------------------------------------------------------------------------
+
+DEFAULT_RANGE = '30d'
+RANGE_CHOICES = ('7d', '30d', '90d', 'custom')
+
+
+def resolve_window(range_key, start_str=None, end_str=None, *, now=None):
+    """Resolve a ``(start, end)`` datetime tuple from filter params.
+
+    ``range_key`` is one of ``7d``, ``30d``, ``90d``, ``custom``. For
+    ``custom`` the ISO date strings ``start_str`` and ``end_str`` are
+    parsed (YYYY-MM-DD); end is shifted to end-of-day so the day is
+    inclusive.
+
+    Falls back to the default 30-day window if any input is invalid.
+    Returns timezone-aware datetimes in the current TZ (UTC by default).
+    """
+    if now is None:
+        now = timezone.now()
+
+    if range_key == 'custom' and start_str and end_str:
+        try:
+            start_date = datetime.strptime(start_str, '%Y-%m-%d').date()
+            end_date = datetime.strptime(end_str, '%Y-%m-%d').date()
+        except ValueError:
+            range_key = DEFAULT_RANGE
+        else:
+            tz = timezone.get_current_timezone()
+            start = timezone.make_aware(datetime.combine(start_date, time.min), tz)
+            end = timezone.make_aware(datetime.combine(end_date, time.max), tz)
+            return start, end
+
+    days_map = {'7d': 7, '30d': 30, '90d': 90}
+    days = days_map.get(range_key, 30)
+    return now - timedelta(days=days), now
+
+
+# ---------------------------------------------------------------------------
+# Visits
+# ---------------------------------------------------------------------------
+
+def visits_for(start, end, *, campaign_slug=None, utm_content=None,
+               utm_source=None, utm_medium=None):
+    """Return a CampaignVisit queryset filtered by the given parameters."""
+    qs = CampaignVisit.objects.filter(ts__gte=start, ts__lte=end)
+    if campaign_slug:
+        qs = qs.filter(utm_campaign=campaign_slug)
+    if utm_content:
+        qs = qs.filter(utm_content=utm_content)
+    if utm_source:
+        qs = qs.filter(utm_source=utm_source)
+    if utm_medium:
+        qs = qs.filter(utm_medium=utm_medium)
+    return qs
+
+
+def visit_count(start, end, **filters):
+    return visits_for(start, end, **filters).count()
+
+
+def unique_visitor_count(start, end, **filters):
+    return (
+        visits_for(start, end, **filters)
+        .order_by()  # clear default `-ts` ordering so distinct() is on anonymous_id only
+        .values('anonymous_id')
+        .distinct()
+        .count()
+    )
+
+
+def distinct_utm_values(start, end, field, **filters):
+    """Return a sorted list of distinct non-empty values for a UTM field."""
+    qs = visits_for(start, end, **filters)
+    values = (
+        qs.exclude(**{field: ''})
+        .order_by()  # clear default `-ts` ordering so distinct() is on `field` only
+        .values_list(field, flat=True)
+        .distinct()
+    )
+    return sorted(values)
+
+
+# ---------------------------------------------------------------------------
+# Signups (UserAttribution)
+# ---------------------------------------------------------------------------
+
+def _attribution_field(attribution, suffix):
+    """Return either ``first_touch_<suffix>`` or ``last_touch_<suffix>``."""
+    prefix = 'last_touch_' if attribution == 'last_touch' else 'first_touch_'
+    return prefix + suffix
+
+
+def signups_for(start, end, *, campaign_slug=None, utm_content=None,
+                utm_source=None, utm_medium=None, attribution='first_touch'):
+    """Return a UserAttribution queryset filtered by the given parameters.
+
+    For ``attribution='last_touch'`` the queries swap to the
+    ``last_touch_*`` fields (and ``last_touch_ts`` for the date window).
+    """
+    ts_field = _attribution_field(attribution, 'ts')
+    campaign_field = _attribution_field(attribution, 'utm_campaign')
+    content_field = _attribution_field(attribution, 'utm_content')
+    source_field = _attribution_field(attribution, 'utm_source')
+    medium_field = _attribution_field(attribution, 'utm_medium')
+
+    qs = UserAttribution.objects.filter(
+        **{f'{ts_field}__gte': start, f'{ts_field}__lte': end}
+    )
+    if campaign_slug:
+        qs = qs.filter(**{campaign_field: campaign_slug})
+    if utm_content:
+        qs = qs.filter(**{content_field: utm_content})
+    if utm_source:
+        qs = qs.filter(**{source_field: utm_source})
+    if utm_medium:
+        qs = qs.filter(**{medium_field: utm_medium})
+    return qs
+
+
+def signup_count(start, end, **filters):
+    return signups_for(start, end, **filters).count()
+
+
+# ---------------------------------------------------------------------------
+# Conversions + MRR (ConversionAttribution)
+# ---------------------------------------------------------------------------
+
+def conversions_for(start, end, *, campaign_slug=None, utm_content=None,
+                    utm_source=None, utm_medium=None,
+                    attribution='first_touch'):
+    """Return a ConversionAttribution queryset, or .none() if model absent."""
+    model = _conversion_model()
+    if model is None:
+        return CampaignVisit.objects.none()  # consistent .count() / iteration
+
+    campaign_field = _attribution_field(attribution, 'utm_campaign')
+    content_field = _attribution_field(attribution, 'utm_content')
+    source_field = _attribution_field(attribution, 'utm_source')
+    medium_field = _attribution_field(attribution, 'utm_medium')
+
+    qs = model.objects.filter(created_at__gte=start, created_at__lte=end)
+    if campaign_slug:
+        qs = qs.filter(**{campaign_field: campaign_slug})
+    if utm_content:
+        qs = qs.filter(**{content_field: utm_content})
+    if utm_source:
+        qs = qs.filter(**{source_field: utm_source})
+    if utm_medium:
+        qs = qs.filter(**{medium_field: utm_medium})
+    return qs
+
+
+def conversion_count(start, end, **filters):
+    qs = conversions_for(start, end, **filters)
+    if not hasattr(qs, 'count'):
+        return 0
+    return qs.count()
+
+
+def mrr_for(start, end, **filters):
+    """Sum of monthly-equivalent EUR for matching conversions.
+
+    Uses the per-row ``mrr_eur`` value computed at conversion time
+    (``payments.services._record_conversion_attribution`` already
+    normalises yearly to monthly by dividing by 12). One-off course
+    purchases have ``mrr_eur=NULL`` and are excluded.
+
+    Returns ``Decimal('0')`` when there are no rows so the dashboard
+    never has to handle ``None``.
+    """
+    qs = conversions_for(start, end, **filters)
+    if _conversion_model() is None:
+        return Decimal('0')
+    total = 0
+    for amount in qs.values_list('mrr_eur', flat=True):
+        if amount is not None:
+            total += int(amount)
+    return Decimal(total)
+
+
+# ---------------------------------------------------------------------------
+# Conversion-rate formatter
+# ---------------------------------------------------------------------------
+
+def conversion_rate(numerator, denominator):
+    """Format a percentage as ``"12.3%"`` or ``"n/a"`` when denom is zero.
+
+    Per acceptance criterion: never show ``"0.0%"`` when there is no
+    data — show ``"n/a"`` so the empty-data state is unambiguous.
+    """
+    if not denominator:
+        return 'n/a'
+    pct = (numerator / denominator) * 100
+    return f'{pct:.1f}%'
+
+
+# ---------------------------------------------------------------------------
+# Daily buckets (sparkline data)
+# ---------------------------------------------------------------------------
+
+def daily_buckets(start, end, *, metric='visits', campaign_slug=None,
+                  utm_content=None, utm_source=None, utm_medium=None,
+                  attribution='first_touch'):
+    """Return a list of ``(date, count)`` for the given metric.
+
+    Always returns one entry per day in the [start, end] window so the
+    sparkline polyline has consistent x-axis spacing even on zero-count
+    days. ``metric`` is one of ``visits``, ``signups``.
+    """
+    if metric == 'signups':
+        qs = signups_for(
+            start, end,
+            campaign_slug=campaign_slug,
+            utm_content=utm_content,
+            utm_source=utm_source,
+            utm_medium=utm_medium,
+            attribution=attribution,
+        )
+        ts_field = _attribution_field(attribution, 'ts')
+    else:
+        qs = visits_for(
+            start, end,
+            campaign_slug=campaign_slug,
+            utm_content=utm_content,
+            utm_source=utm_source,
+            utm_medium=utm_medium,
+        )
+        ts_field = 'ts'
+
+    raw = qs.extra(select={'day': f'DATE({ts_field})'}).values('day').annotate(c=Count('*'))
+    # Some backends return strings, some date objects.
+    by_day = {}
+    for row in raw:
+        day = row['day']
+        if isinstance(day, str):
+            try:
+                day = datetime.strptime(day, '%Y-%m-%d').date()
+            except ValueError:
+                continue
+        by_day[day] = row['c']
+
+    out = []
+    cursor = start.date()
+    end_date = end.date()
+    while cursor <= end_date:
+        out.append((cursor, by_day.get(cursor, 0)))
+        cursor += timedelta(days=1)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Per-campaign rollup (one row per Campaign with at least one visit)
+# ---------------------------------------------------------------------------
+
+def campaign_rollup(start, end, *, utm_source=None, utm_medium=None,
+                    attribution='first_touch'):
+    """Return a list of dicts, one per campaign with visits in window.
+
+    Each dict has the keys used by the dashboard table: ``slug``,
+    ``visits``, ``unique_visitors``, ``signups``, ``conversions``,
+    ``mrr``, ``visit_to_signup_pct``, ``signup_to_paid_pct``,
+    ``utm_source``, ``utm_medium``. Rows are sorted by ``visits`` desc.
+    """
+    visit_qs = visits_for(start, end, utm_source=utm_source, utm_medium=utm_medium)
+    rows = (
+        visit_qs.exclude(utm_campaign='')
+        .values('utm_campaign')
+        .annotate(
+            visits=Count('id'),
+            unique_visitors=Count('anonymous_id', distinct=True),
+        )
+        .order_by('-visits')
+    )
+
+    out = []
+    for row in rows:
+        slug = row['utm_campaign']
+        signups = signup_count(
+            start, end,
+            campaign_slug=slug,
+            utm_source=utm_source,
+            utm_medium=utm_medium,
+            attribution=attribution,
+        )
+        conversions = conversion_count(
+            start, end,
+            campaign_slug=slug,
+            utm_source=utm_source,
+            utm_medium=utm_medium,
+            attribution=attribution,
+        )
+        mrr = mrr_for(
+            start, end,
+            campaign_slug=slug,
+            utm_source=utm_source,
+            utm_medium=utm_medium,
+            attribution=attribution,
+        )
+
+        # Distinct source / medium values for visits to this campaign
+        sources = sorted(
+            visit_qs.filter(utm_campaign=slug)
+            .exclude(utm_source='')
+            .order_by()
+            .values_list('utm_source', flat=True)
+            .distinct()
+        )
+        mediums = sorted(
+            visit_qs.filter(utm_campaign=slug)
+            .exclude(utm_medium='')
+            .order_by()
+            .values_list('utm_medium', flat=True)
+            .distinct()
+        )
+
+        out.append({
+            'slug': slug,
+            'visits': row['visits'],
+            'unique_visitors': row['unique_visitors'],
+            'signups': signups,
+            'conversions': conversions,
+            'mrr': mrr,
+            'visit_to_signup_pct': conversion_rate(signups, row['unique_visitors']),
+            'signup_to_paid_pct': conversion_rate(conversions, signups),
+            'utm_sources': sources,
+            'utm_mediums': mediums,
+        })
+    return out
+
+
+def utm_content_rollup(start, end, *, campaign_slug, utm_source=None,
+                       utm_medium=None, attribution='first_touch'):
+    """One row per ``utm_content`` value within a single campaign."""
+    visit_qs = visits_for(
+        start, end,
+        campaign_slug=campaign_slug,
+        utm_source=utm_source,
+        utm_medium=utm_medium,
+    )
+    rows = (
+        visit_qs.values('utm_content')
+        .annotate(
+            visits=Count('id'),
+            unique_visitors=Count('anonymous_id', distinct=True),
+        )
+        .order_by('-visits')
+    )
+
+    out = []
+    for row in rows:
+        content = row['utm_content']
+        # Pass blank utm_content through as exact match to count "no-content" visits.
+        signups = signup_count(
+            start, end,
+            campaign_slug=campaign_slug,
+            utm_content=content,
+            utm_source=utm_source,
+            utm_medium=utm_medium,
+            attribution=attribution,
+        )
+        conversions = conversion_count(
+            start, end,
+            campaign_slug=campaign_slug,
+            utm_content=content,
+            utm_source=utm_source,
+            utm_medium=utm_medium,
+            attribution=attribution,
+        )
+        mrr = mrr_for(
+            start, end,
+            campaign_slug=campaign_slug,
+            utm_content=content,
+            utm_source=utm_source,
+            utm_medium=utm_medium,
+            attribution=attribution,
+        )
+        out.append({
+            'utm_content': content,
+            'visits': row['visits'],
+            'unique_visitors': row['unique_visitors'],
+            'signups': signups,
+            'conversions': conversions,
+            'mrr': mrr,
+            'visit_to_signup_pct': conversion_rate(signups, row['unique_visitors']),
+            'signup_to_paid_pct': conversion_rate(conversions, signups),
+        })
+    return out
+
+
+# ---------------------------------------------------------------------------
+# KPI strip helper
+# ---------------------------------------------------------------------------
+
+def kpi_strip(start, end, *, campaign_slug=None, utm_content=None,
+              utm_source=None, utm_medium=None, attribution='first_touch'):
+    """Return the KPI-card numbers used by all three views."""
+    common = dict(
+        campaign_slug=campaign_slug,
+        utm_content=utm_content,
+        utm_source=utm_source,
+        utm_medium=utm_medium,
+    )
+    visits = visit_count(start, end, **common)
+    uniques = unique_visitor_count(start, end, **common)
+    signups = signup_count(start, end, attribution=attribution, **common)
+    conversions = conversion_count(start, end, attribution=attribution, **common)
+    mrr = mrr_for(start, end, attribution=attribution, **common)
+    return {
+        'visits': visits,
+        'unique_visitors': uniques,
+        'signups': signups,
+        'conversions': conversions,
+        'mrr': mrr,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Filter dropdown helpers (distinct source / medium from window)
+# ---------------------------------------------------------------------------
+
+def filter_options(start, end):
+    """Distinct source / medium values seen in the date window."""
+    base_qs = CampaignVisit.objects.filter(ts__gte=start, ts__lte=end)
+    # `.order_by()` clears the model's default `ordering = ['-ts']`,
+    # otherwise `.distinct()` would include `ts` in the SELECT and we'd
+    # get one row per (source, ts) pair instead of distinct sources.
+    sources = sorted(
+        base_qs.exclude(utm_source='')
+        .order_by()
+        .values_list('utm_source', flat=True)
+        .distinct()
+    )
+    mediums = sorted(
+        base_qs.exclude(utm_medium='')
+        .order_by()
+        .values_list('utm_medium', flat=True)
+        .distinct()
+    )
+    return {'sources': sources, 'mediums': mediums}
+
+
+# ---------------------------------------------------------------------------
+# Sparkline path generator
+# ---------------------------------------------------------------------------
+
+def sparkline_polyline(buckets, *, width=120, height=24):
+    """Return an SVG `points` string for the given (date, count) buckets.
+
+    Empty / single-bucket data returns ''. The caller is responsible for
+    wrapping the polyline in ``<svg>...</svg>``.
+    """
+    if not buckets or len(buckets) < 2:
+        return ''
+    counts = [c for _, c in buckets]
+    max_v = max(counts)
+    if max_v == 0:
+        max_v = 1
+    n = len(buckets) - 1
+    points = []
+    for i, (_, c) in enumerate(buckets):
+        x = (i / n) * width
+        y = height - (c / max_v) * height
+        points.append(f'{x:.1f},{y:.1f}')
+    return ' '.join(points)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+__all__ = [
+    'DEFAULT_RANGE',
+    'RANGE_CHOICES',
+    'campaign_rollup',
+    'conversion_count',
+    'conversion_rate',
+    'conversions_for',
+    'daily_buckets',
+    'distinct_utm_values',
+    'filter_options',
+    'has_conversion_data',
+    'kpi_strip',
+    'mrr_for',
+    'resolve_window',
+    'signup_count',
+    'signups_for',
+    'sparkline_polyline',
+    'unique_visitor_count',
+    'utm_content_rollup',
+    'visit_count',
+    'visits_for',
+]

--- a/analytics/tests/test_aggregations.py
+++ b/analytics/tests/test_aggregations.py
@@ -1,0 +1,327 @@
+"""Tests for the analytics.aggregations helper module (#196).
+
+These cover the unit-level guarantees the dashboard view relies on:
+- Empty data returns 0 / Decimal('0') / 'n/a' rather than blowing up.
+- First-touch vs last-touch swaps which UserAttribution fields are queried.
+- Annual subscriptions are normalised to monthly when summing MRR.
+- Conversion-rate formatter shows 'n/a' on zero denominators.
+- Date-window helpers parse `7d`, `30d`, `90d`, and `custom` correctly.
+"""
+
+from datetime import datetime, timedelta
+from datetime import timezone as dt_timezone
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils import timezone
+
+from analytics import aggregations
+from analytics.models import CampaignVisit, UserAttribution
+from integrations.models import UtmCampaign
+
+User = get_user_model()
+
+
+def _make_visit(slug, *, content='', source='newsletter', medium='email',
+                anon='aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', ts=None):
+    visit = CampaignVisit.objects.create(
+        utm_campaign=slug,
+        utm_content=content,
+        utm_source=source,
+        utm_medium=medium,
+        anonymous_id=anon,
+    )
+    if ts is not None:
+        CampaignVisit.objects.filter(pk=visit.pk).update(ts=ts)
+        visit.refresh_from_db()
+    return visit
+
+
+def _make_attribution(user, *, slug='launch_april', content='ai_hero_list',
+                      source='newsletter', medium='email',
+                      first_ts=None, last_slug=None, last_content=None,
+                      last_source=None, last_medium=None, last_ts=None):
+    """Create or replace a UserAttribution row for the given user."""
+    UserAttribution.objects.filter(user=user).delete()
+    attr = UserAttribution.objects.create(
+        user=user,
+        first_touch_utm_campaign=slug,
+        first_touch_utm_content=content,
+        first_touch_utm_source=source,
+        first_touch_utm_medium=medium,
+        first_touch_ts=first_ts or timezone.now(),
+        last_touch_utm_campaign=last_slug or slug,
+        last_touch_utm_content=last_content or content,
+        last_touch_utm_source=last_source or source,
+        last_touch_utm_medium=last_medium or medium,
+        last_touch_ts=last_ts or first_ts or timezone.now(),
+        signup_path='email_password',
+    )
+    return attr
+
+
+class ResolveWindowTest(TestCase):
+    def test_default_range_is_30_days(self):
+        now = datetime(2026, 4, 17, 12, 0, tzinfo=dt_timezone.utc)
+        start, end = aggregations.resolve_window('30d', now=now)
+        self.assertEqual((end - start).days, 30)
+
+    def test_seven_day_window(self):
+        now = datetime(2026, 4, 17, 12, 0, tzinfo=dt_timezone.utc)
+        start, end = aggregations.resolve_window('7d', now=now)
+        self.assertEqual((end - start).days, 7)
+
+    def test_invalid_range_falls_back_to_default(self):
+        now = datetime(2026, 4, 17, 12, 0, tzinfo=dt_timezone.utc)
+        start, end = aggregations.resolve_window('garbage', now=now)
+        self.assertEqual((end - start).days, 30)
+
+    def test_custom_range_with_iso_dates(self):
+        start, end = aggregations.resolve_window('custom', '2026-04-01', '2026-04-10')
+        self.assertEqual(start.year, 2026)
+        self.assertEqual(start.month, 4)
+        self.assertEqual(start.day, 1)
+        self.assertEqual(end.day, 10)
+        # End should be end-of-day so the date is inclusive.
+        self.assertEqual(end.hour, 23)
+
+    def test_custom_range_with_invalid_dates_falls_back(self):
+        now = datetime(2026, 4, 17, 12, 0, tzinfo=dt_timezone.utc)
+        start, end = aggregations.resolve_window('custom', 'not-a-date', '', now=now)
+        self.assertEqual((end - start).days, 30)
+
+
+class ConversionRateTest(TestCase):
+    def test_zero_denominator_returns_na(self):
+        self.assertEqual(aggregations.conversion_rate(0, 0), 'n/a')
+        self.assertEqual(aggregations.conversion_rate(5, 0), 'n/a')
+
+    def test_normal_rate_one_decimal(self):
+        self.assertEqual(aggregations.conversion_rate(10, 100), '10.0%')
+
+    def test_fractional_rate(self):
+        self.assertEqual(aggregations.conversion_rate(1, 3), '33.3%')
+
+    def test_zero_numerator_returns_zero_pct(self):
+        # Spec: "n/a" only when denominator is zero. With 0/100 we want "0.0%".
+        self.assertEqual(aggregations.conversion_rate(0, 100), '0.0%')
+
+
+class EmptyDataTest(TestCase):
+    """All helpers must return safe defaults with no data in the DB."""
+
+    def test_visit_count_is_zero(self):
+        start = timezone.now() - timedelta(days=30)
+        end = timezone.now()
+        self.assertEqual(aggregations.visit_count(start, end), 0)
+
+    def test_unique_visitor_count_is_zero(self):
+        start = timezone.now() - timedelta(days=30)
+        end = timezone.now()
+        self.assertEqual(aggregations.unique_visitor_count(start, end), 0)
+
+    def test_signup_count_is_zero(self):
+        start = timezone.now() - timedelta(days=30)
+        end = timezone.now()
+        self.assertEqual(aggregations.signup_count(start, end), 0)
+
+    def test_mrr_is_decimal_zero(self):
+        start = timezone.now() - timedelta(days=30)
+        end = timezone.now()
+        self.assertEqual(aggregations.mrr_for(start, end), Decimal('0'))
+
+    def test_campaign_rollup_is_empty_list(self):
+        start = timezone.now() - timedelta(days=30)
+        end = timezone.now()
+        self.assertEqual(aggregations.campaign_rollup(start, end), [])
+
+    def test_kpi_strip_all_zero(self):
+        start = timezone.now() - timedelta(days=30)
+        end = timezone.now()
+        kpis = aggregations.kpi_strip(start, end)
+        self.assertEqual(kpis['visits'], 0)
+        self.assertEqual(kpis['unique_visitors'], 0)
+        self.assertEqual(kpis['signups'], 0)
+        self.assertEqual(kpis['conversions'], 0)
+        self.assertEqual(kpis['mrr'], Decimal('0'))
+
+
+class CampaignRollupTest(TestCase):
+    """Top-level rollup with seeded data."""
+
+    def setUp(self):
+        UtmCampaign.objects.create(
+            name='Launch April', slug='launch_april',
+            default_utm_source='newsletter', default_utm_medium='email',
+        )
+        # 3 visits, 2 unique
+        _make_visit('launch_april', anon='a1')
+        _make_visit('launch_april', anon='a1')
+        _make_visit('launch_april', anon='a2')
+
+        # 1 unique visit on a different campaign
+        _make_visit('older_campaign', anon='b1')
+
+    def test_returns_one_row_per_campaign_with_visits(self):
+        start = timezone.now() - timedelta(days=1)
+        end = timezone.now() + timedelta(hours=1)
+        rows = aggregations.campaign_rollup(start, end)
+        slugs = [r['slug'] for r in rows]
+        self.assertIn('launch_april', slugs)
+        self.assertIn('older_campaign', slugs)
+
+    def test_rows_sorted_by_visits_desc(self):
+        start = timezone.now() - timedelta(days=1)
+        end = timezone.now() + timedelta(hours=1)
+        rows = aggregations.campaign_rollup(start, end)
+        # launch_april has 3 visits, older_campaign has 1
+        self.assertEqual(rows[0]['slug'], 'launch_april')
+        self.assertEqual(rows[0]['visits'], 3)
+        self.assertEqual(rows[0]['unique_visitors'], 2)
+
+    def test_visit_to_signup_uses_unique_visitors(self):
+        # Add a signup attributed to launch_april
+        u = User.objects.create_user(email='alice@test.com', password='x')
+        _make_attribution(u, slug='launch_april')
+        start = timezone.now() - timedelta(days=1)
+        end = timezone.now() + timedelta(hours=1)
+        rows = aggregations.campaign_rollup(start, end)
+        launch = next(r for r in rows if r['slug'] == 'launch_april')
+        # 1 signup / 2 unique visitors = 50%
+        self.assertEqual(launch['signups'], 1)
+        self.assertEqual(launch['visit_to_signup_pct'], '50.0%')
+
+    def test_zero_signups_shows_na_for_signup_to_paid(self):
+        start = timezone.now() - timedelta(days=1)
+        end = timezone.now() + timedelta(hours=1)
+        rows = aggregations.campaign_rollup(start, end)
+        for r in rows:
+            self.assertEqual(r['signup_to_paid_pct'], 'n/a')
+
+
+class FirstVsLastTouchTest(TestCase):
+    """Toggling attribution swaps which UserAttribution fields are queried."""
+
+    def setUp(self):
+        # User who first arrived via campaign A and later via campaign B.
+        self.user = User.objects.create_user(email='split@test.com', password='x')
+        _make_attribution(
+            self.user,
+            slug='campaign_a', content='nl1', source='newsletter',
+            last_slug='campaign_b', last_content='tw1', last_source='twitter',
+        )
+
+    def test_first_touch_credits_campaign_a(self):
+        start = timezone.now() - timedelta(days=1)
+        end = timezone.now() + timedelta(hours=1)
+        a = aggregations.signup_count(start, end, campaign_slug='campaign_a',
+                                      attribution='first_touch')
+        b = aggregations.signup_count(start, end, campaign_slug='campaign_b',
+                                      attribution='first_touch')
+        self.assertEqual(a, 1)
+        self.assertEqual(b, 0)
+
+    def test_last_touch_credits_campaign_b(self):
+        start = timezone.now() - timedelta(days=1)
+        end = timezone.now() + timedelta(hours=1)
+        a = aggregations.signup_count(start, end, campaign_slug='campaign_a',
+                                      attribution='last_touch')
+        b = aggregations.signup_count(start, end, campaign_slug='campaign_b',
+                                      attribution='last_touch')
+        self.assertEqual(a, 0)
+        self.assertEqual(b, 1)
+
+
+class MrrAnnualNormalisationTest(TestCase):
+    """Annual subscriptions normalised to monthly when summing MRR."""
+
+    def setUp(self):
+        from payments.models import ConversionAttribution, Tier
+        self.tier_basic = Tier.objects.create(
+            slug='basic_test', name='Basic', level=99,
+            price_eur_month=10, price_eur_year=120,
+        )
+        self.user1 = User.objects.create_user(email='a@test.com', password='x')
+        self.user2 = User.objects.create_user(email='b@test.com', password='x')
+        # Monthly conversion: mrr_eur stored as price_eur_month
+        ConversionAttribution.objects.create(
+            user=self.user1,
+            stripe_session_id='cs_monthly_1',
+            tier=self.tier_basic,
+            billing_period='monthly',
+            amount_eur=10,
+            mrr_eur=10,
+            first_touch_utm_campaign='launch_april',
+        )
+        # Annual conversion: mrr_eur stored as price_eur_year // 12
+        ConversionAttribution.objects.create(
+            user=self.user2,
+            stripe_session_id='cs_annual_1',
+            tier=self.tier_basic,
+            billing_period='yearly',
+            amount_eur=120,
+            mrr_eur=120 // 12,
+            first_touch_utm_campaign='launch_april',
+        )
+
+    def test_mrr_sums_monthly_plus_normalised_annual(self):
+        start = timezone.now() - timedelta(days=1)
+        end = timezone.now() + timedelta(hours=1)
+        total = aggregations.mrr_for(start, end, campaign_slug='launch_april')
+        # 10 (monthly) + 10 (120/12) = 20
+        self.assertEqual(total, Decimal(20))
+
+    def test_one_off_purchase_with_null_mrr_excluded(self):
+        from payments.models import ConversionAttribution
+        u3 = User.objects.create_user(email='c@test.com', password='x')
+        ConversionAttribution.objects.create(
+            user=u3,
+            stripe_session_id='cs_course_1',
+            tier=None,
+            billing_period='',
+            amount_eur=49,
+            mrr_eur=None,
+            first_touch_utm_campaign='launch_april',
+        )
+        start = timezone.now() - timedelta(days=1)
+        end = timezone.now() + timedelta(hours=1)
+        total = aggregations.mrr_for(start, end, campaign_slug='launch_april')
+        # Same 20 as above — the one-off shouldn't add anything
+        self.assertEqual(total, Decimal(20))
+
+
+class SparklinePolylineTest(TestCase):
+    def test_empty_returns_blank(self):
+        self.assertEqual(aggregations.sparkline_polyline([]), '')
+
+    def test_single_point_returns_blank(self):
+        from datetime import date
+        self.assertEqual(aggregations.sparkline_polyline([(date.today(), 5)]), '')
+
+    def test_multi_point_renders_x_y_pairs(self):
+        from datetime import date
+        from datetime import timedelta as td
+        today = date.today()
+        buckets = [(today - td(days=i), i) for i in range(5)]
+        result = aggregations.sparkline_polyline(buckets, width=100, height=20)
+        # 5 points means 5 space-separated x,y pairs
+        self.assertEqual(len(result.split(' ')), 5)
+        # Last point should be at x=100 (rightmost)
+        self.assertTrue(result.endswith(',0.0'))
+
+
+class FilterOptionsTest(TestCase):
+    """Source / medium dropdowns are populated from distinct visit values."""
+
+    def setUp(self):
+        _make_visit('c1', source='newsletter', medium='email')
+        _make_visit('c1', source='twitter', medium='social')
+        _make_visit('c1', source='newsletter', medium='email')  # dup
+
+    def test_returns_distinct_sorted_values(self):
+        start = timezone.now() - timedelta(days=1)
+        end = timezone.now() + timedelta(hours=1)
+        opts = aggregations.filter_options(start, end)
+        self.assertEqual(opts['sources'], ['newsletter', 'twitter'])
+        self.assertEqual(opts['mediums'], ['email', 'social'])

--- a/studio/tests/test_utm_analytics.py
+++ b/studio/tests/test_utm_analytics.py
@@ -1,0 +1,514 @@
+"""Tests for the Studio UTM Analytics views (#196).
+
+Covers acceptance criteria:
+- Access control (anonymous, free user, staff)
+- Empty-state rendering
+- Campaign rollup table sort + content
+- Date range filter (7d / 30d / 90d / custom)
+- First-touch / last-touch toggle
+- utm_source / utm_medium dropdown filters
+- Drill-down navigation (campaign + link)
+- Pagination on link detail visits table
+- KPI strip rendering
+- Conversion-rate "n/a" semantics in template output
+- Sidebar "Analytics" section presence
+- Sparkline column renders inline SVG (no JS lib)
+"""
+
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+from django.utils import timezone
+
+from analytics.models import CampaignVisit, UserAttribution
+from integrations.models import UtmCampaign, UtmCampaignLink
+from payments.models import ConversionAttribution, Tier
+
+User = get_user_model()
+
+
+def _staff_login(client, email='staff@test.com'):
+    user = User.objects.create_user(email=email, password='pw', is_staff=True)
+    client.login(email=email, password='pw')
+    return user
+
+
+def _user_login(client, email='free@test.com'):
+    user = User.objects.create_user(email=email, password='pw', is_staff=False)
+    client.login(email=email, password='pw')
+    return user
+
+
+def _seed_visit(slug, *, content='', source='newsletter', medium='email',
+                anon='aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', ts=None):
+    v = CampaignVisit.objects.create(
+        utm_campaign=slug,
+        utm_content=content,
+        utm_source=source,
+        utm_medium=medium,
+        anonymous_id=anon,
+    )
+    if ts is not None:
+        CampaignVisit.objects.filter(pk=v.pk).update(ts=ts)
+    return v
+
+
+def _seed_attribution(user, *, slug, content='', source='newsletter',
+                      medium='email', last_slug=None, last_content=None,
+                      last_source=None, last_medium=None,
+                      first_ts=None, last_ts=None):
+    UserAttribution.objects.filter(user=user).delete()
+    return UserAttribution.objects.create(
+        user=user,
+        first_touch_utm_campaign=slug,
+        first_touch_utm_content=content,
+        first_touch_utm_source=source,
+        first_touch_utm_medium=medium,
+        first_touch_ts=first_ts or timezone.now(),
+        last_touch_utm_campaign=last_slug or slug,
+        last_touch_utm_content=last_content or content,
+        last_touch_utm_source=last_source or source,
+        last_touch_utm_medium=last_medium or medium,
+        last_touch_ts=last_ts or first_ts or timezone.now(),
+        signup_path='email_password',
+    )
+
+
+# ---------------------------------------------------------------------------
+# Access control
+# ---------------------------------------------------------------------------
+
+class UtmAnalyticsAccessTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.campaign = UtmCampaign.objects.create(
+            name='Test', slug='launch_april',
+            default_utm_source='newsletter', default_utm_medium='email',
+        )
+        self.link = UtmCampaignLink.objects.create(
+            campaign=self.campaign, utm_content='ai_hero_list',
+            destination='/events/launch',
+        )
+
+    def _paths(self):
+        return [
+            '/studio/utm-analytics/',
+            f'/studio/utm-analytics/campaign/{self.campaign.slug}/',
+            f'/studio/utm-analytics/campaign/{self.campaign.slug}/link/{self.link.pk}/',
+        ]
+
+    def test_anonymous_redirected_to_login(self):
+        for path in self._paths():
+            response = self.client.get(path)
+            self.assertEqual(response.status_code, 302)
+            self.assertIn('/accounts/login/', response['Location'])
+
+    def test_free_user_gets_403(self):
+        _user_login(self.client)
+        for path in self._paths():
+            response = self.client.get(path)
+            self.assertEqual(response.status_code, 403, path)
+
+    def test_staff_user_gets_200(self):
+        _staff_login(self.client)
+        for path in self._paths():
+            response = self.client.get(path)
+            self.assertEqual(response.status_code, 200, path)
+
+
+# ---------------------------------------------------------------------------
+# Dashboard view
+# ---------------------------------------------------------------------------
+
+class UtmDashboardTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        _staff_login(self.client)
+
+    def test_empty_state_message_and_link(self):
+        response = self.client.get('/studio/utm-analytics/')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'No visits captured in this window')
+        self.assertContains(response, 'UTM Campaigns')
+        # CTA link to the builder
+        self.assertContains(response, 'href="/studio/utm-campaigns/"')
+
+    def test_kpi_strip_shows_zero_for_empty(self):
+        response = self.client.get('/studio/utm-analytics/')
+        kpis = response.context['kpis']
+        self.assertEqual(kpis['visits'], 0)
+        self.assertEqual(kpis['unique_visitors'], 0)
+        self.assertEqual(kpis['signups'], 0)
+
+    def test_table_lists_one_row_per_campaign_sorted_desc(self):
+        UtmCampaign.objects.create(
+            name='Launch April', slug='launch_april',
+            default_utm_source='newsletter', default_utm_medium='email',
+        )
+        UtmCampaign.objects.create(
+            name='Older', slug='older_campaign',
+            default_utm_source='newsletter', default_utm_medium='email',
+        )
+        # 100 visits to launch_april, 50 to older
+        for i in range(100):
+            _seed_visit('launch_april', anon=f'anon-{i}')
+        for i in range(50):
+            _seed_visit('older_campaign', anon=f'older-{i}')
+
+        response = self.client.get('/studio/utm-analytics/')
+        rows = response.context['rows']
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]['slug'], 'launch_april')
+        self.assertEqual(rows[0]['visits'], 100)
+        self.assertEqual(rows[1]['slug'], 'older_campaign')
+        self.assertEqual(rows[1]['visits'], 50)
+
+    def test_conversion_rate_shows_na_when_zero_denominator(self):
+        # 1 visit, 0 signups: visit_to_signup is 0.0% (denominator=1).
+        # signup_to_paid_pct is "n/a" because signups=0 (denominator=0).
+        UtmCampaign.objects.create(
+            name='Z', slug='zero_camp',
+            default_utm_source='newsletter', default_utm_medium='email',
+        )
+        _seed_visit('zero_camp', anon='zz1')
+        response = self.client.get('/studio/utm-analytics/')
+        rows = response.context['rows']
+        self.assertEqual(rows[0]['signups'], 0)
+        self.assertEqual(rows[0]['visit_to_signup_pct'], '0.0%')
+        self.assertEqual(rows[0]['signup_to_paid_pct'], 'n/a')
+        # And in the rendered HTML
+        self.assertContains(response, 'n/a')
+
+    def test_date_range_filter_changes_window(self):
+        # Visit from 60 days ago — outside 30d but inside 90d
+        old_ts = timezone.now() - timedelta(days=60)
+        _seed_visit('historic', anon='h1', ts=old_ts)
+        # Visit today
+        _seed_visit('recent', anon='r1')
+
+        # 30d window: only `recent`
+        response = self.client.get('/studio/utm-analytics/?range=30d')
+        slugs = [r['slug'] for r in response.context['rows']]
+        self.assertIn('recent', slugs)
+        self.assertNotIn('historic', slugs)
+
+        # 90d window: both
+        response = self.client.get('/studio/utm-analytics/?range=90d')
+        slugs = [r['slug'] for r in response.context['rows']]
+        self.assertIn('recent', slugs)
+        self.assertIn('historic', slugs)
+
+    def test_first_vs_last_touch_toggle(self):
+        # Seed a visit so the campaigns appear in the rollup
+        _seed_visit('campaign_a', anon='split-1')
+        _seed_visit('campaign_b', anon='split-2')
+
+        u = User.objects.create_user(email='split@test.com', password='x')
+        _seed_attribution(
+            u, slug='campaign_a', last_slug='campaign_b',
+            source='newsletter', last_source='twitter',
+        )
+
+        # First touch credits A
+        response = self.client.get('/studio/utm-analytics/?attribution=first_touch')
+        rows = {r['slug']: r for r in response.context['rows']}
+        self.assertEqual(rows['campaign_a']['signups'], 1)
+        self.assertEqual(rows['campaign_b']['signups'], 0)
+
+        # Last touch credits B
+        response = self.client.get('/studio/utm-analytics/?attribution=last_touch')
+        rows = {r['slug']: r for r in response.context['rows']}
+        self.assertEqual(rows['campaign_a']['signups'], 0)
+        self.assertEqual(rows['campaign_b']['signups'], 1)
+
+    def test_utm_source_filter_populated_from_window(self):
+        _seed_visit('c1', source='newsletter', anon='a1')
+        _seed_visit('c1', source='twitter', anon='a2')
+        _seed_visit('c1', source='linkedin', anon='a3')
+        response = self.client.get('/studio/utm-analytics/')
+        sources = response.context['source_options']
+        self.assertEqual(sources, ['linkedin', 'newsletter', 'twitter'])
+
+    def test_utm_source_filter_narrows_table(self):
+        _seed_visit('c1', source='newsletter', anon='nl1')
+        _seed_visit('c2', source='twitter', anon='tw1')
+        response = self.client.get('/studio/utm-analytics/?utm_source=newsletter')
+        slugs = [r['slug'] for r in response.context['rows']]
+        self.assertIn('c1', slugs)
+        self.assertNotIn('c2', slugs)
+
+    def test_sparkline_renders_inline_svg(self):
+        _seed_visit('c1', anon='s1')
+        _seed_visit('c1', anon='s2', ts=timezone.now() - timedelta(days=2))
+        response = self.client.get('/studio/utm-analytics/')
+        # Must render <svg> inline, not load any JS chart lib
+        self.assertContains(response, '<svg')
+        self.assertContains(response, '<polyline')
+        self.assertNotContains(response, 'chart.js')
+        self.assertNotContains(response, 'd3.min')
+
+    def test_includes_paid_columns_when_conversion_data_available(self):
+        response = self.client.get('/studio/utm-analytics/')
+        # ConversionAttribution model exists -> has_conversion_data is True
+        self.assertTrue(response.context['has_conversion_data'])
+        self.assertContains(response, 'Paid Conversions')
+        self.assertContains(response, 'MRR')
+
+
+# ---------------------------------------------------------------------------
+# Campaign drill-down
+# ---------------------------------------------------------------------------
+
+class UtmCampaignDetailViewTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        _staff_login(self.client)
+        self.campaign = UtmCampaign.objects.create(
+            name='Launch April', slug='launch_april',
+            default_utm_source='newsletter', default_utm_medium='email',
+        )
+        self.link_hero = UtmCampaignLink.objects.create(
+            campaign=self.campaign, utm_content='ai_hero_list',
+            destination='/events/launch', label='AI Hero list',
+        )
+        self.link_maven = UtmCampaignLink.objects.create(
+            campaign=self.campaign, utm_content='maven_list',
+            destination='/events/launch',
+        )
+        # 60 visits to ai_hero_list (40 unique), 35 to maven_list (35 unique)
+        for i in range(60):
+            anon = f'hero-{i % 40}'
+            _seed_visit('launch_april', content='ai_hero_list', anon=anon)
+        for i in range(35):
+            _seed_visit('launch_april', content='maven_list', anon=f'maven-{i}')
+
+    def test_breadcrumb_contains_campaign_name(self):
+        response = self.client.get('/studio/utm-analytics/campaign/launch_april/')
+        self.assertContains(response, 'UTM Analytics')
+        self.assertContains(response, 'Launch April')
+
+    def test_one_row_per_utm_content_sorted_desc(self):
+        response = self.client.get('/studio/utm-analytics/campaign/launch_april/')
+        rows = response.context['rows']
+        contents = [r['utm_content'] for r in rows]
+        self.assertEqual(contents, ['ai_hero_list', 'maven_list'])
+        self.assertEqual(rows[0]['visits'], 60)
+        self.assertEqual(rows[1]['visits'], 35)
+
+    def test_view_link_action_present_when_link_exists(self):
+        response = self.client.get('/studio/utm-analytics/campaign/launch_april/')
+        # Link to the link detail page should appear
+        self.assertContains(
+            response,
+            f'/studio/utm-analytics/campaign/launch_april/link/{self.link_hero.pk}/',
+        )
+
+    def test_label_shown_beneath_utm_content(self):
+        response = self.client.get('/studio/utm-analytics/campaign/launch_april/')
+        self.assertContains(response, 'AI Hero list')
+
+    def test_destination_shown_truncated(self):
+        response = self.client.get('/studio/utm-analytics/campaign/launch_april/')
+        self.assertContains(response, '/events/launch')
+
+    def test_unknown_campaign_slug_renders_with_blank_table(self):
+        response = self.client.get('/studio/utm-analytics/campaign/never_existed/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['rows'], [])
+
+
+# ---------------------------------------------------------------------------
+# Link drill-down
+# ---------------------------------------------------------------------------
+
+class UtmLinkDetailViewTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        _staff_login(self.client)
+        self.campaign = UtmCampaign.objects.create(
+            name='Launch April', slug='launch_april',
+            default_utm_source='newsletter', default_utm_medium='email',
+        )
+        self.link = UtmCampaignLink.objects.create(
+            campaign=self.campaign, utm_content='ai_hero_list',
+            destination='/events/launch', label='AI Hero list',
+        )
+        # 60 visits
+        for i in range(60):
+            _seed_visit(
+                'launch_april', content='ai_hero_list',
+                anon=f'visitor-{i:02d}',
+            )
+
+    def test_assembled_url_shown_with_copy_button(self):
+        response = self.client.get(
+            f'/studio/utm-analytics/campaign/launch_april/link/{self.link.pk}/'
+        )
+        self.assertContains(response, 'utm_campaign=launch_april')
+        self.assertContains(response, 'utm_content=ai_hero_list')
+        self.assertContains(response, 'Copy')
+
+    def test_visits_table_paginates_at_20(self):
+        response = self.client.get(
+            f'/studio/utm-analytics/campaign/launch_april/link/{self.link.pk}/'
+        )
+        self.assertEqual(response.context['paginator'].num_pages, 3)
+        self.assertEqual(len(response.context['visits_page'].object_list), 20)
+
+    def test_pagination_page_2_shows_next_20(self):
+        response = self.client.get(
+            f'/studio/utm-analytics/campaign/launch_april/link/{self.link.pk}/?page=2'
+        )
+        self.assertEqual(response.context['visits_page'].number, 2)
+        self.assertEqual(len(response.context['visits_page'].object_list), 20)
+
+    def test_conversion_rows_for_attributed_users(self):
+        # 8 users attributed to ai_hero_list
+        for i in range(8):
+            u = User.objects.create_user(
+                email=f'paid-{i}@test.com', password='x',
+            )
+            _seed_attribution(
+                u, slug='launch_april', content='ai_hero_list',
+            )
+        response = self.client.get(
+            f'/studio/utm-analytics/campaign/launch_april/link/{self.link.pk}/'
+        )
+        self.assertEqual(len(response.context['conversion_rows']), 8)
+        for row in response.context['conversion_rows']:
+            self.assertIn('@test.com', row['email'])
+
+    def test_link_not_under_campaign_returns_404(self):
+        other = UtmCampaign.objects.create(
+            name='Other', slug='other_camp',
+            default_utm_source='newsletter', default_utm_medium='email',
+        )
+        other_link = UtmCampaignLink.objects.create(
+            campaign=other, utm_content='x', destination='/x',
+        )
+        response = self.client.get(
+            f'/studio/utm-analytics/campaign/launch_april/link/{other_link.pk}/'
+        )
+        self.assertEqual(response.status_code, 404)
+
+
+# ---------------------------------------------------------------------------
+# Filter preservation across drill-downs
+# ---------------------------------------------------------------------------
+
+class FilterPreservationTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        _staff_login(self.client)
+        UtmCampaign.objects.create(
+            name='Launch April', slug='launch_april',
+            default_utm_source='newsletter', default_utm_medium='email',
+        )
+        for i in range(5):
+            _seed_visit('launch_april', anon=f'a{i}')
+
+    def test_dashboard_drill_down_link_preserves_range(self):
+        response = self.client.get('/studio/utm-analytics/?range=7d')
+        # The drill-down link in the row must include ?range=7d
+        self.assertContains(
+            response,
+            'href="/studio/utm-analytics/campaign/launch_april/?range=7d"',
+        )
+
+    def test_campaign_drill_down_link_preserves_attribution(self):
+        response = self.client.get(
+            '/studio/utm-analytics/?attribution=last_touch'
+        )
+        self.assertContains(response, 'attribution=last_touch')
+
+
+# ---------------------------------------------------------------------------
+# Conversion data graceful degradation
+# ---------------------------------------------------------------------------
+
+class GracefulDegradationTest(TestCase):
+    """When ConversionAttribution data is absent, MRR + Paid columns hide.
+
+    We can't physically remove the model so we monkeypatch the
+    ``has_conversion_data`` check used by the dashboard view + template.
+    """
+
+    def setUp(self):
+        self.client = Client()
+        _staff_login(self.client)
+
+    def test_paid_columns_hidden_when_conversion_data_absent(self):
+        from analytics import aggregations
+        original = aggregations.has_conversion_data
+        aggregations.has_conversion_data = lambda: False
+        try:
+            response = self.client.get('/studio/utm-analytics/')
+            self.assertEqual(response.status_code, 200)
+            # KPI cards for paid + MRR should NOT be rendered
+            self.assertNotContains(response, 'Paid Conversions')
+            self.assertNotContains(response, 'MRR Added')
+        finally:
+            aggregations.has_conversion_data = original
+
+
+# ---------------------------------------------------------------------------
+# MRR rendering
+# ---------------------------------------------------------------------------
+
+class MrrRenderingTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        _staff_login(self.client)
+        self.campaign = UtmCampaign.objects.create(
+            name='Launch April', slug='launch_april',
+            default_utm_source='newsletter', default_utm_medium='email',
+        )
+        self.tier = Tier.objects.create(
+            slug='tier_test_mrr', name='Test', level=98,
+            price_eur_month=10, price_eur_year=120,
+        )
+        # Generate one visit so launch_april appears in the rollup
+        _seed_visit('launch_april', anon='vmrr1')
+        u = User.objects.create_user(email='paid-mrr@test.com', password='x')
+        ConversionAttribution.objects.create(
+            user=u, stripe_session_id='cs_mrr_1',
+            tier=self.tier, billing_period='monthly',
+            amount_eur=10, mrr_eur=10,
+            first_touch_utm_campaign='launch_april',
+        )
+        u2 = User.objects.create_user(email='paid-mrr-2@test.com', password='x')
+        ConversionAttribution.objects.create(
+            user=u2, stripe_session_id='cs_mrr_2',
+            tier=self.tier, billing_period='yearly',
+            amount_eur=120, mrr_eur=10,
+            first_touch_utm_campaign='launch_april',
+        )
+
+    def test_dashboard_shows_mrr_eur_summed(self):
+        response = self.client.get('/studio/utm-analytics/')
+        rows = response.context['rows']
+        launch = next(r for r in rows if r['slug'] == 'launch_april')
+        # 10 (monthly) + 10 (annual normalised) = 20
+        self.assertEqual(launch['mrr'], 20)
+        self.assertEqual(launch['conversions'], 2)
+        self.assertContains(response, 'EUR 20')
+
+
+# ---------------------------------------------------------------------------
+# Sidebar nav (acceptance criterion)
+# ---------------------------------------------------------------------------
+
+class SidebarTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        _staff_login(self.client)
+
+    def test_dashboard_sidebar_has_analytics_section(self):
+        response = self.client.get('/studio/')
+        self.assertEqual(response.status_code, 200)
+        # The "Analytics" group label
+        self.assertContains(response, 'Analytics')
+        # Both links present
+        self.assertContains(response, 'href="/studio/utm-campaigns/"')
+        self.assertContains(response, 'href="/studio/utm-analytics/"')

--- a/studio/urls.py
+++ b/studio/urls.py
@@ -45,6 +45,15 @@ from studio.views.settings import settings_dashboard, settings_save_group
 from studio.views.subscribers import subscriber_export_csv, subscriber_list
 from studio.views.sync import sync_all, sync_dashboard, sync_history, sync_status, sync_trigger
 from studio.views.tier_overrides import tier_override_create, tier_override_page, tier_override_revoke
+from studio.views.utm_analytics import (
+    utm_campaign_detail as utm_analytics_campaign_detail,
+)
+from studio.views.utm_analytics import (
+    utm_dashboard,
+)
+from studio.views.utm_analytics import (
+    utm_link_detail as utm_analytics_link_detail,
+)
 from studio.views.utm_campaigns import (
     utm_campaign_archive,
     utm_campaign_create,
@@ -117,6 +126,19 @@ urlpatterns = [
     path('utm-campaigns/<int:campaign_id>/links/add', utm_link_create, name='studio_utm_link_create'),
     path('utm-campaigns/<int:campaign_id>/links/<int:link_id>/edit', utm_link_edit, name='studio_utm_link_edit'),
     path('utm-campaigns/<int:campaign_id>/links/<int:link_id>/archive', utm_link_archive, name='studio_utm_link_archive'),
+
+    # UTM Analytics
+    path('utm-analytics/', utm_dashboard, name='studio_utm_dashboard'),
+    path(
+        'utm-analytics/campaign/<slug:campaign_slug>/',
+        utm_analytics_campaign_detail,
+        name='studio_utm_campaign_analytics',
+    ),
+    path(
+        'utm-analytics/campaign/<slug:campaign_slug>/link/<int:link_id>/',
+        utm_analytics_link_detail,
+        name='studio_utm_link_analytics',
+    ),
 
     # Subscribers
     path('subscribers/', subscriber_list, name='studio_subscriber_list'),

--- a/studio/views/utm_analytics.py
+++ b/studio/views/utm_analytics.py
@@ -1,0 +1,325 @@
+"""Studio views for the UTM Analytics dashboard (#196).
+
+Three server-rendered views:
+
+- ``utm_dashboard`` — top-level rollup, one row per campaign with visits
+- ``utm_campaign_detail`` — drill-down per ``utm_content`` for a campaign
+- ``utm_link_detail`` — visits + conversions audit trail for one link
+
+All three accept the same query params: ``range`` (7d/30d/90d/custom),
+``start`` + ``end`` (when range=custom), ``attribution`` (first_touch /
+last_touch), ``utm_source``, ``utm_medium``. Filters are preserved
+across drill-downs.
+
+No HTMX, no JS chart lib — matches the existing Studio pattern in
+``subscribers/list.html`` (GET form, ``onchange="this.form.submit()"``).
+Sparklines are inline SVG polylines.
+"""
+
+from urllib.parse import urlencode
+
+from django.core.paginator import Paginator
+from django.shortcuts import get_object_or_404, render
+
+from analytics import aggregations
+from analytics.models import CampaignVisit
+from integrations.models import UtmCampaign, UtmCampaignLink
+from studio.decorators import staff_required
+
+# ---------------------------------------------------------------------------
+# Filter parsing
+# ---------------------------------------------------------------------------
+
+def _parse_filters(request):
+    """Pull filter params off the request and resolve the date window."""
+    range_key = request.GET.get('range', aggregations.DEFAULT_RANGE)
+    if range_key not in aggregations.RANGE_CHOICES:
+        range_key = aggregations.DEFAULT_RANGE
+    start_str = request.GET.get('start', '')
+    end_str = request.GET.get('end', '')
+    attribution = request.GET.get('attribution', 'first_touch')
+    if attribution not in ('first_touch', 'last_touch'):
+        attribution = 'first_touch'
+    utm_source = request.GET.get('utm_source', '').strip()
+    utm_medium = request.GET.get('utm_medium', '').strip()
+
+    start, end = aggregations.resolve_window(range_key, start_str, end_str)
+
+    return {
+        'range_key': range_key,
+        'start_str': start_str,
+        'end_str': end_str,
+        'attribution': attribution,
+        'utm_source': utm_source,
+        'utm_medium': utm_medium,
+        'start': start,
+        'end': end,
+    }
+
+
+def _filters_querystring(filters):
+    """Encode the active filters as a ``?key=value&...`` string.
+
+    Used to preserve filters when navigating between dashboard, campaign
+    drill-down, and link drill-down.
+    """
+    params = {}
+    if filters['range_key'] != aggregations.DEFAULT_RANGE:
+        params['range'] = filters['range_key']
+    if filters['range_key'] == 'custom':
+        if filters['start_str']:
+            params['start'] = filters['start_str']
+        if filters['end_str']:
+            params['end'] = filters['end_str']
+    if filters['attribution'] != 'first_touch':
+        params['attribution'] = filters['attribution']
+    if filters['utm_source']:
+        params['utm_source'] = filters['utm_source']
+    if filters['utm_medium']:
+        params['utm_medium'] = filters['utm_medium']
+    if not params:
+        return ''
+    return '?' + urlencode(params)
+
+
+def _sparkline_for(start, end, *, campaign_slug=None, utm_content=None,
+                   utm_source=None, utm_medium=None, attribution='first_touch'):
+    """Return an inline-SVG-ready dict with visit + signup polyline points."""
+    visits = aggregations.daily_buckets(
+        start, end, metric='visits',
+        campaign_slug=campaign_slug, utm_content=utm_content,
+        utm_source=utm_source, utm_medium=utm_medium,
+    )
+    signups = aggregations.daily_buckets(
+        start, end, metric='signups',
+        campaign_slug=campaign_slug, utm_content=utm_content,
+        utm_source=utm_source, utm_medium=utm_medium,
+        attribution=attribution,
+    )
+    visit_counts = [c for _, c in visits]
+    signup_counts = [c for _, c in signups]
+    max_v = max(visit_counts + signup_counts) if (visit_counts or signup_counts) else 0
+    return {
+        'visits_points': aggregations.sparkline_polyline(visits),
+        'signups_points': aggregations.sparkline_polyline(signups),
+        'has_data': max_v > 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Dashboard view
+# ---------------------------------------------------------------------------
+
+@staff_required
+def utm_dashboard(request):
+    """Top-level rollup: one row per campaign with visits in the window."""
+    filters = _parse_filters(request)
+    common = dict(
+        utm_source=filters['utm_source'] or None,
+        utm_medium=filters['utm_medium'] or None,
+        attribution=filters['attribution'],
+    )
+
+    kpis = aggregations.kpi_strip(filters['start'], filters['end'], **common)
+    rows = aggregations.campaign_rollup(filters['start'], filters['end'], **common)
+
+    # Resolve UtmCampaign records for slugs that exist in the table so we
+    # can show the human-readable name and link to the builder for "Edit
+    # campaign". Slugs without a matching UtmCampaign are still shown
+    # (visits with stale / unknown utm_campaign values).
+    campaign_map = {
+        c.slug: c for c in UtmCampaign.objects.filter(slug__in=[r['slug'] for r in rows])
+    }
+    for r in rows:
+        camp = campaign_map.get(r['slug'])
+        r['campaign'] = camp
+        r['name'] = camp.name if camp else r['slug']
+        r['sparkline'] = _sparkline_for(
+            filters['start'], filters['end'],
+            campaign_slug=r['slug'],
+            **common,
+        )
+
+    options = aggregations.filter_options(filters['start'], filters['end'])
+
+    context = {
+        'filters': filters,
+        'querystring': _filters_querystring(filters),
+        'kpis': kpis,
+        'rows': rows,
+        'has_conversion_data': aggregations.has_conversion_data(),
+        'source_options': options['sources'],
+        'medium_options': options['mediums'],
+        'is_dashboard': True,
+    }
+    return render(request, 'studio/utm_analytics/dashboard.html', context)
+
+
+# ---------------------------------------------------------------------------
+# Campaign drill-down view
+# ---------------------------------------------------------------------------
+
+@staff_required
+def utm_campaign_detail(request, campaign_slug):
+    """Drill-down per ``utm_content`` for a single campaign.
+
+    Uses the slug rather than the PK so the URL stays meaningful when a
+    campaign exists in visits but not in ``UtmCampaign`` (e.g. a UTM
+    parameter shipped with a typo). When the slug doesn't match any
+    ``UtmCampaign`` row, ``campaign`` is None and we render with the
+    slug as the breadcrumb label.
+    """
+    filters = _parse_filters(request)
+    common = dict(
+        utm_source=filters['utm_source'] or None,
+        utm_medium=filters['utm_medium'] or None,
+        attribution=filters['attribution'],
+    )
+
+    campaign = UtmCampaign.objects.filter(slug=campaign_slug).first()
+
+    kpis = aggregations.kpi_strip(
+        filters['start'], filters['end'],
+        campaign_slug=campaign_slug, **common,
+    )
+    rows = aggregations.utm_content_rollup(
+        filters['start'], filters['end'],
+        campaign_slug=campaign_slug, **common,
+    )
+
+    # Map utm_content -> UtmCampaignLink (so we can show label + Actions)
+    link_map = {}
+    if campaign:
+        for link in campaign.links.all():
+            link_map[link.utm_content] = link
+    for r in rows:
+        link = link_map.get(r['utm_content'])
+        r['link'] = link
+        r['label'] = link.label if link else ''
+        r['destination'] = link.destination if link else ''
+        r['sparkline'] = _sparkline_for(
+            filters['start'], filters['end'],
+            campaign_slug=campaign_slug,
+            utm_content=r['utm_content'],
+            **common,
+        )
+
+    options = aggregations.filter_options(filters['start'], filters['end'])
+
+    context = {
+        'filters': filters,
+        'querystring': _filters_querystring(filters),
+        'campaign': campaign,
+        'campaign_slug': campaign_slug,
+        'campaign_name': campaign.name if campaign else campaign_slug,
+        'kpis': kpis,
+        'rows': rows,
+        'has_conversion_data': aggregations.has_conversion_data(),
+        'source_options': options['sources'],
+        'medium_options': options['mediums'],
+    }
+    return render(request, 'studio/utm_analytics/campaign_detail.html', context)
+
+
+# ---------------------------------------------------------------------------
+# Link drill-down view
+# ---------------------------------------------------------------------------
+
+@staff_required
+def utm_link_detail(request, campaign_slug, link_id):
+    """Visits + conversions audit trail for a single ``UtmCampaignLink``."""
+    filters = _parse_filters(request)
+    common = dict(
+        utm_source=filters['utm_source'] or None,
+        utm_medium=filters['utm_medium'] or None,
+        attribution=filters['attribution'],
+    )
+
+    campaign = get_object_or_404(UtmCampaign, slug=campaign_slug)
+    link = get_object_or_404(UtmCampaignLink, pk=link_id, campaign=campaign)
+
+    kpis = aggregations.kpi_strip(
+        filters['start'], filters['end'],
+        campaign_slug=campaign_slug, utm_content=link.utm_content,
+        **common,
+    )
+
+    visit_qs = (
+        CampaignVisit.objects
+        .filter(
+            ts__gte=filters['start'],
+            ts__lte=filters['end'],
+            utm_campaign=campaign_slug,
+            utm_content=link.utm_content,
+        )
+        .select_related('user')
+        .order_by('-ts')
+    )
+    if filters['utm_source']:
+        visit_qs = visit_qs.filter(utm_source=filters['utm_source'])
+    if filters['utm_medium']:
+        visit_qs = visit_qs.filter(utm_medium=filters['utm_medium'])
+
+    paginator = Paginator(visit_qs, 20)
+    page_number = request.GET.get('page', 1)
+    try:
+        visits_page = paginator.page(page_number)
+    except Exception:
+        visits_page = paginator.page(1)
+
+    # Build URL prefixes for prev/next pagination links that preserve filters.
+    base_qs = _filters_querystring(filters)
+    if base_qs:
+        page_link_prefix = f'{base_qs}&page='
+    else:
+        page_link_prefix = '?page='
+
+    # Conversions table — one row per signed-up user attributed to this link
+    signups = aggregations.signups_for(
+        filters['start'], filters['end'],
+        campaign_slug=campaign_slug,
+        utm_content=link.utm_content,
+        utm_source=filters['utm_source'] or None,
+        utm_medium=filters['utm_medium'] or None,
+        attribution=filters['attribution'],
+    ).select_related('user', 'user__tier')
+
+    conversion_rows = []
+    for sa in signups:
+        user = sa.user
+        # Did this user pay? Look up the most recent ConversionAttribution
+        # if the model exists — graceful no-op when payments hasn't shipped.
+        paid = False
+        mrr = None
+        model = aggregations._conversion_model()
+        if model is not None and user is not None:
+            ca = model.objects.filter(user=user).order_by('-created_at').first()
+            if ca is not None:
+                paid = bool(ca.tier_id)
+                mrr = ca.mrr_eur
+        conversion_rows.append({
+            'user': user,
+            'email': user.email if user else '',
+            'signup_ts': getattr(sa, aggregations._attribution_field(filters['attribution'], 'ts')),
+            'tier': user.tier if user and user.tier_id else None,
+            'paid': paid,
+            'mrr': mrr or 0,
+        })
+
+    context = {
+        'filters': filters,
+        'querystring': _filters_querystring(filters),
+        'campaign': campaign,
+        'link': link,
+        'kpis': kpis,
+        'visits_page': visits_page,
+        'paginator': paginator,
+        'page_link_prefix': page_link_prefix,
+        'conversion_rows': conversion_rows,
+        'has_conversion_data': aggregations.has_conversion_data(),
+        'assembled_url': link.build_url(),
+    }
+    return render(request, 'studio/utm_analytics/link_detail.html', context)
+
+
+__all__ = ['utm_dashboard', 'utm_campaign_detail', 'utm_link_detail']

--- a/templates/studio/base.html
+++ b/templates/studio/base.html
@@ -85,6 +85,20 @@
               </a>
             </li>
             <li>
+              <a href="{% url 'studio_notification_log' %}"
+                 class="flex items-center space-x-3 px-3 py-2 rounded-lg text-sm {% if 'notifications' in request.path %}bg-secondary text-foreground{% else %}text-muted-foreground hover:text-foreground hover:bg-secondary{% endif %} transition-colors">
+                <i data-lucide="bell" class="w-4 h-4"></i>
+                <span>Notifications</span>
+              </a>
+            </li>
+          </ul>
+        </div>
+
+        <!-- Analytics Section -->
+        <div>
+          <p class="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">Analytics</p>
+          <ul class="space-y-1">
+            <li>
               <a href="{% url 'studio_utm_campaign_list' %}"
                  class="flex items-center space-x-3 px-3 py-2 rounded-lg text-sm {% if 'utm-campaigns' in request.path %}bg-secondary text-foreground{% else %}text-muted-foreground hover:text-foreground hover:bg-secondary{% endif %} transition-colors">
                 <i data-lucide="link" class="w-4 h-4"></i>
@@ -92,10 +106,10 @@
               </a>
             </li>
             <li>
-              <a href="{% url 'studio_notification_log' %}"
-                 class="flex items-center space-x-3 px-3 py-2 rounded-lg text-sm {% if 'notifications' in request.path %}bg-secondary text-foreground{% else %}text-muted-foreground hover:text-foreground hover:bg-secondary{% endif %} transition-colors">
-                <i data-lucide="bell" class="w-4 h-4"></i>
-                <span>Notifications</span>
+              <a href="{% url 'studio_utm_dashboard' %}"
+                 class="flex items-center space-x-3 px-3 py-2 rounded-lg text-sm {% if 'utm-analytics' in request.path %}bg-secondary text-foreground{% else %}text-muted-foreground hover:text-foreground hover:bg-secondary{% endif %} transition-colors">
+                <i data-lucide="bar-chart-3" class="w-4 h-4"></i>
+                <span>UTM Analytics</span>
               </a>
             </li>
           </ul>

--- a/templates/studio/utm_analytics/_filters.html
+++ b/templates/studio/utm_analytics/_filters.html
@@ -1,0 +1,59 @@
+{# Shared GET-form filter bar for the three UTM Analytics views. #}
+<form method="get" class="bg-card border border-border rounded-lg p-4 mb-6 flex flex-wrap items-end gap-3">
+  <div>
+    <label class="block text-xs font-medium text-muted-foreground mb-1" for="filter-range">Date range</label>
+    <select id="filter-range" name="range" onchange="this.form.submit()"
+            class="bg-secondary border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-accent">
+      <option value="7d" {% if filters.range_key == '7d' %}selected{% endif %}>Last 7 days</option>
+      <option value="30d" {% if filters.range_key == '30d' %}selected{% endif %}>Last 30 days</option>
+      <option value="90d" {% if filters.range_key == '90d' %}selected{% endif %}>Last 90 days</option>
+      <option value="custom" {% if filters.range_key == 'custom' %}selected{% endif %}>Custom</option>
+    </select>
+  </div>
+
+  {% if filters.range_key == 'custom' %}
+  <div>
+    <label class="block text-xs font-medium text-muted-foreground mb-1" for="filter-start">Start (YYYY-MM-DD)</label>
+    <input id="filter-start" type="date" name="start" value="{{ filters.start_str }}"
+           class="bg-secondary border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-accent">
+  </div>
+  <div>
+    <label class="block text-xs font-medium text-muted-foreground mb-1" for="filter-end">End (YYYY-MM-DD)</label>
+    <input id="filter-end" type="date" name="end" value="{{ filters.end_str }}"
+           class="bg-secondary border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-accent">
+  </div>
+  {% endif %}
+
+  <div>
+    <label class="block text-xs font-medium text-muted-foreground mb-1" for="filter-attr">Attribution</label>
+    <select id="filter-attr" name="attribution" onchange="this.form.submit()"
+            class="bg-secondary border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-accent">
+      <option value="first_touch" {% if filters.attribution == 'first_touch' %}selected{% endif %}>First touch</option>
+      <option value="last_touch" {% if filters.attribution == 'last_touch' %}selected{% endif %}>Last touch</option>
+    </select>
+  </div>
+
+  <div>
+    <label class="block text-xs font-medium text-muted-foreground mb-1" for="filter-source">utm_source</label>
+    <select id="filter-source" name="utm_source" onchange="this.form.submit()"
+            class="bg-secondary border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-accent">
+      <option value="">All sources</option>
+      {% for source in source_options %}
+      <option value="{{ source }}" {% if filters.utm_source == source %}selected{% endif %}>{{ source }}</option>
+      {% endfor %}
+    </select>
+  </div>
+
+  <div>
+    <label class="block text-xs font-medium text-muted-foreground mb-1" for="filter-medium">utm_medium</label>
+    <select id="filter-medium" name="utm_medium" onchange="this.form.submit()"
+            class="bg-secondary border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-accent">
+      <option value="">All mediums</option>
+      {% for medium in medium_options %}
+      <option value="{{ medium }}" {% if filters.utm_medium == medium %}selected{% endif %}>{{ medium }}</option>
+      {% endfor %}
+    </select>
+  </div>
+
+  <button type="submit" class="bg-accent text-accent-foreground px-4 py-2 rounded-lg text-sm font-medium hover:opacity-90 transition-opacity">Apply</button>
+</form>

--- a/templates/studio/utm_analytics/_kpis.html
+++ b/templates/studio/utm_analytics/_kpis.html
@@ -1,0 +1,25 @@
+{# Shared KPI strip used by all three UTM Analytics views. #}
+<div class="grid grid-cols-2 md:grid-cols-3 {% if has_conversion_data %}lg:grid-cols-5{% else %}lg:grid-cols-3{% endif %} gap-4 mb-6">
+  <div class="bg-card border border-border rounded-lg p-4">
+    <p class="text-xs text-muted-foreground uppercase tracking-wider">Total Visits</p>
+    <p class="text-2xl font-semibold text-foreground mt-1">{{ kpis.visits }}</p>
+  </div>
+  <div class="bg-card border border-border rounded-lg p-4">
+    <p class="text-xs text-muted-foreground uppercase tracking-wider">Unique Visitors</p>
+    <p class="text-2xl font-semibold text-foreground mt-1">{{ kpis.unique_visitors }}</p>
+  </div>
+  <div class="bg-card border border-border rounded-lg p-4">
+    <p class="text-xs text-muted-foreground uppercase tracking-wider">Signups</p>
+    <p class="text-2xl font-semibold text-foreground mt-1">{{ kpis.signups }}</p>
+  </div>
+  {% if has_conversion_data %}
+  <div class="bg-card border border-border rounded-lg p-4">
+    <p class="text-xs text-muted-foreground uppercase tracking-wider">Paid Conversions</p>
+    <p class="text-2xl font-semibold text-foreground mt-1">{{ kpis.conversions }}</p>
+  </div>
+  <div class="bg-card border border-border rounded-lg p-4">
+    <p class="text-xs text-muted-foreground uppercase tracking-wider">MRR Added</p>
+    <p class="text-2xl font-semibold text-foreground mt-1">EUR {{ kpis.mrr|floatformat:0 }}</p>
+  </div>
+  {% endif %}
+</div>

--- a/templates/studio/utm_analytics/campaign_detail.html
+++ b/templates/studio/utm_analytics/campaign_detail.html
@@ -1,0 +1,107 @@
+{% extends "studio/base.html" %}
+
+{% block studio_title %}{{ campaign_name }} - UTM Analytics{% endblock %}
+
+{% block studio_content %}
+<nav class="text-sm text-muted-foreground mb-3">
+  <a href="{% url 'studio_utm_dashboard' %}{{ querystring }}" class="hover:text-accent">UTM Analytics</a>
+  <span class="mx-2">&gt;</span>
+  <span class="text-foreground">{{ campaign_name }}</span>
+</nav>
+
+<div class="mb-6 flex items-start justify-between gap-3">
+  <div>
+    <h1 class="text-2xl font-semibold text-foreground">{{ campaign_name }}</h1>
+    <p class="text-xs font-mono text-muted-foreground mt-1">{{ campaign_slug }}</p>
+  </div>
+  {% if campaign %}
+  <a href="{% url 'studio_utm_campaign_detail' campaign_id=campaign.pk %}"
+     class="bg-secondary border border-border text-foreground px-4 py-2 rounded-lg text-sm font-medium hover:bg-muted transition-colors shrink-0">
+    Edit campaign
+  </a>
+  {% endif %}
+</div>
+
+{% include "studio/utm_analytics/_filters.html" %}
+
+{% include "studio/utm_analytics/_kpis.html" %}
+
+{% if rows %}
+<div class="bg-card border border-border rounded-lg overflow-x-auto">
+  <table class="w-full">
+    <thead class="bg-secondary">
+      <tr>
+        <th class="text-left px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">utm_content</th>
+        <th class="text-left px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider hidden md:table-cell">Destination</th>
+        <th class="text-right px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">Visits</th>
+        <th class="text-right px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider hidden lg:table-cell">Unique</th>
+        <th class="text-right px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">Signups</th>
+        <th class="text-right px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider hidden md:table-cell">Visit -&gt; Signup</th>
+        {% if has_conversion_data %}
+        <th class="text-right px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">Paid</th>
+        <th class="text-right px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider hidden md:table-cell">Signup -&gt; Paid</th>
+        <th class="text-right px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">MRR EUR</th>
+        {% endif %}
+        <th class="text-left px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider hidden xl:table-cell">Trend</th>
+        <th class="text-right px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">Actions</th>
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-border">
+      {% for row in rows %}
+      <tr class="hover:bg-secondary/50 transition-colors">
+        <td class="px-4 py-4 text-sm">
+          <span class="text-foreground font-medium font-mono">{{ row.utm_content|default:"(blank)" }}</span>
+          {% if row.label %}<p class="text-xs text-muted-foreground mt-0.5">{{ row.label }}</p>{% endif %}
+        </td>
+        <td class="px-4 py-4 text-sm text-muted-foreground hidden md:table-cell">
+          {% if row.destination %}
+          <span title="{{ row.destination }}" class="break-all">{{ row.destination|truncatechars:50 }}</span>
+          {% else %}
+          <span class="text-xs">—</span>
+          {% endif %}
+        </td>
+        <td class="px-4 py-4 text-sm text-foreground text-right font-medium">{{ row.visits }}</td>
+        <td class="px-4 py-4 text-sm text-muted-foreground text-right hidden lg:table-cell">{{ row.unique_visitors }}</td>
+        <td class="px-4 py-4 text-sm text-foreground text-right font-medium">{{ row.signups }}</td>
+        <td class="px-4 py-4 text-sm text-muted-foreground text-right hidden md:table-cell">{{ row.visit_to_signup_pct }}</td>
+        {% if has_conversion_data %}
+        <td class="px-4 py-4 text-sm text-foreground text-right font-medium">{{ row.conversions }}</td>
+        <td class="px-4 py-4 text-sm text-muted-foreground text-right hidden md:table-cell">{{ row.signup_to_paid_pct }}</td>
+        <td class="px-4 py-4 text-sm text-foreground text-right font-medium">EUR {{ row.mrr|floatformat:0 }}</td>
+        {% endif %}
+        <td class="px-4 py-4 hidden xl:table-cell">
+          {% if row.sparkline.has_data %}
+          <svg width="120" height="24" viewBox="0 0 120 24" class="overflow-visible" aria-label="Trend sparkline">
+            {% if row.sparkline.visits_points %}
+            <polyline points="{{ row.sparkline.visits_points }}" fill="none" stroke="#94a3b8" stroke-width="1.5" />
+            {% endif %}
+            {% if row.sparkline.signups_points %}
+            <polyline points="{{ row.sparkline.signups_points }}" fill="none" stroke="#22c55e" stroke-width="1.5" />
+            {% endif %}
+          </svg>
+          {% else %}
+          <span class="text-xs text-muted-foreground">—</span>
+          {% endif %}
+        </td>
+        <td class="px-4 py-4 text-right text-sm space-x-2 whitespace-nowrap">
+          {% if row.link %}
+          <a href="{% url 'studio_utm_link_analytics' campaign_slug=campaign_slug link_id=row.link.pk %}{{ querystring }}"
+             class="text-accent hover:underline">View link</a>
+          {% else %}
+          <span class="text-xs text-muted-foreground">No minted link</span>
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% else %}
+<div class="bg-card border border-border rounded-lg p-12 text-center">
+  <p class="text-foreground mb-2">No visits for this campaign in this window.</p>
+  <p class="text-sm text-muted-foreground">
+    Try widening the date range or check that links for this campaign have been shared.
+  </p>
+</div>
+{% endif %}
+{% endblock %}

--- a/templates/studio/utm_analytics/dashboard.html
+++ b/templates/studio/utm_analytics/dashboard.html
@@ -1,0 +1,100 @@
+{% extends "studio/base.html" %}
+
+{% block studio_title %}UTM Analytics{% endblock %}
+
+{% block studio_content %}
+<div class="mb-6">
+  <h1 class="text-2xl font-semibold text-foreground">UTM Analytics</h1>
+  <p class="text-muted-foreground mt-1">Visits to signups to paid conversions, broken down by UTM campaign.</p>
+</div>
+
+{% include "studio/utm_analytics/_filters.html" %}
+
+{% include "studio/utm_analytics/_kpis.html" %}
+
+{% if rows %}
+<div class="bg-card border border-border rounded-lg overflow-x-auto">
+  <table class="w-full">
+    <thead class="bg-secondary">
+      <tr>
+        <th class="text-left px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">Campaign</th>
+        <th class="text-left px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider hidden md:table-cell">Source / Medium</th>
+        <th class="text-right px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">Visits</th>
+        <th class="text-right px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider hidden lg:table-cell">Unique</th>
+        <th class="text-right px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">Signups</th>
+        <th class="text-right px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider hidden md:table-cell">Visit -&gt; Signup</th>
+        {% if has_conversion_data %}
+        <th class="text-right px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">Paid</th>
+        <th class="text-right px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider hidden md:table-cell">Signup -&gt; Paid</th>
+        <th class="text-right px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">MRR EUR</th>
+        {% endif %}
+        <th class="text-left px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider hidden xl:table-cell">Trend</th>
+        <th class="text-right px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">Actions</th>
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-border">
+      {% for row in rows %}
+      <tr class="hover:bg-secondary/50 transition-colors">
+        <td class="px-4 py-4 text-sm">
+          <a href="{% url 'studio_utm_campaign_analytics' campaign_slug=row.slug %}{{ querystring }}"
+             class="text-foreground hover:text-accent font-medium">{{ row.name }}</a>
+          <p class="text-xs text-muted-foreground font-mono mt-0.5">{{ row.slug }}</p>
+        </td>
+        <td class="px-4 py-4 text-sm text-muted-foreground hidden md:table-cell">
+          {{ row.utm_sources|join:", " }}
+          {% if row.utm_mediums %} / {{ row.utm_mediums|join:", " }}{% endif %}
+        </td>
+        <td class="px-4 py-4 text-sm text-foreground text-right font-medium">{{ row.visits }}</td>
+        <td class="px-4 py-4 text-sm text-muted-foreground text-right hidden lg:table-cell">{{ row.unique_visitors }}</td>
+        <td class="px-4 py-4 text-sm text-foreground text-right font-medium">{{ row.signups }}</td>
+        <td class="px-4 py-4 text-sm text-muted-foreground text-right hidden md:table-cell">{{ row.visit_to_signup_pct }}</td>
+        {% if has_conversion_data %}
+        <td class="px-4 py-4 text-sm text-foreground text-right font-medium">{{ row.conversions }}</td>
+        <td class="px-4 py-4 text-sm text-muted-foreground text-right hidden md:table-cell">{{ row.signup_to_paid_pct }}</td>
+        <td class="px-4 py-4 text-sm text-foreground text-right font-medium">EUR {{ row.mrr|floatformat:0 }}</td>
+        {% endif %}
+        <td class="px-4 py-4 hidden xl:table-cell">
+          {% if row.sparkline.has_data %}
+          <svg width="120" height="24" viewBox="0 0 120 24" class="overflow-visible" aria-label="Trend sparkline">
+            {% if row.sparkline.visits_points %}
+            <polyline points="{{ row.sparkline.visits_points }}" fill="none" stroke="#94a3b8" stroke-width="1.5" />
+            {% endif %}
+            {% if row.sparkline.signups_points %}
+            <polyline points="{{ row.sparkline.signups_points }}" fill="none" stroke="#22c55e" stroke-width="1.5" />
+            {% endif %}
+          </svg>
+          {% else %}
+          <span class="text-xs text-muted-foreground">—</span>
+          {% endif %}
+        </td>
+        <td class="px-4 py-4 text-right text-sm space-x-2 whitespace-nowrap">
+          <a href="{% url 'studio_utm_campaign_analytics' campaign_slug=row.slug %}{{ querystring }}"
+             class="text-accent hover:underline">Drill down</a>
+          {% if row.campaign %}
+          <a href="{% url 'studio_utm_campaign_detail' campaign_id=row.campaign.pk %}"
+             class="text-muted-foreground hover:text-accent">Edit campaign</a>
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<p class="mt-3 text-xs text-muted-foreground">
+  Sparkline: <span style="color:#94a3b8">visits</span> over <span style="color:#22c55e">signups</span> for the selected window.
+</p>
+{% else %}
+<div class="bg-card border border-border rounded-lg p-12 text-center">
+  <p class="text-foreground mb-2">No visits captured in this window.</p>
+  <p class="text-sm text-muted-foreground mb-4">
+    Visits are logged once a UTM-tagged link is clicked. Mint a link in the
+    <a href="{% url 'studio_utm_campaign_list' %}" class="text-accent hover:underline">UTM Campaigns</a> builder.
+  </p>
+  <a href="{% url 'studio_utm_campaign_list' %}"
+     class="inline-block bg-accent text-accent-foreground px-4 py-2 rounded-lg text-sm font-medium hover:opacity-90 transition-opacity">
+    Open UTM Campaigns
+  </a>
+</div>
+{% endif %}
+{% endblock %}

--- a/templates/studio/utm_analytics/link_detail.html
+++ b/templates/studio/utm_analytics/link_detail.html
@@ -1,0 +1,142 @@
+{% extends "studio/base.html" %}
+
+{% block studio_title %}{{ link.utm_content }} - {{ campaign.name }}{% endblock %}
+
+{% block studio_content %}
+<nav class="text-sm text-muted-foreground mb-3">
+  <a href="{% url 'studio_utm_dashboard' %}{{ querystring }}" class="hover:text-accent">UTM Analytics</a>
+  <span class="mx-2">&gt;</span>
+  <a href="{% url 'studio_utm_campaign_analytics' campaign_slug=campaign.slug %}{{ querystring }}" class="hover:text-accent">{{ campaign.name }}</a>
+  <span class="mx-2">&gt;</span>
+  <span class="text-foreground">{{ link.utm_content }}</span>
+</nav>
+
+<div class="mb-6">
+  <h1 class="text-2xl font-semibold text-foreground">{{ link.utm_content }}</h1>
+  {% if link.label %}<p class="text-sm text-muted-foreground mt-1">{{ link.label }}</p>{% endif %}
+</div>
+
+{% include "studio/utm_analytics/_filters.html" %}
+
+{# Link summary card #}
+<div class="bg-card border border-border rounded-lg p-6 mb-6">
+  <h2 class="text-lg font-semibold text-foreground mb-3">Link summary</h2>
+  <dl class="space-y-3 text-sm">
+    <div>
+      <dt class="text-xs text-muted-foreground uppercase tracking-wider mb-1">Destination</dt>
+      <dd class="text-foreground break-all font-mono">{{ link.destination }}</dd>
+    </div>
+    <div>
+      <dt class="text-xs text-muted-foreground uppercase tracking-wider mb-1">Assembled UTM URL</dt>
+      <dd class="flex items-center gap-2">
+        <code id="assembled-url" class="text-foreground break-all font-mono text-xs flex-1 bg-secondary px-2 py-1 rounded">{{ assembled_url }}</code>
+        <button type="button" onclick="navigator.clipboard.writeText(document.getElementById('assembled-url').innerText)"
+                class="bg-secondary border border-border text-foreground px-3 py-1 rounded text-xs hover:bg-muted transition-colors shrink-0">
+          Copy
+        </button>
+      </dd>
+    </div>
+  </dl>
+</div>
+
+{% include "studio/utm_analytics/_kpis.html" %}
+
+{# Visits table #}
+<div class="bg-card border border-border rounded-lg p-6 mb-6">
+  <h2 class="text-lg font-semibold text-foreground mb-4">Visits</h2>
+  {% if visits_page.object_list %}
+  <div class="overflow-x-auto">
+    <table class="w-full">
+      <thead class="bg-secondary">
+        <tr>
+          <th class="text-left px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">Timestamp</th>
+          <th class="text-left px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">Anon ID</th>
+          <th class="text-left px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider hidden md:table-cell">User</th>
+          <th class="text-left px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider hidden md:table-cell">Path</th>
+          <th class="text-left px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider hidden lg:table-cell">Referrer</th>
+          <th class="text-left px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider hidden lg:table-cell">User agent</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-border">
+        {% for v in visits_page.object_list %}
+        <tr class="hover:bg-secondary/50 transition-colors">
+          <td class="px-4 py-3 text-sm text-foreground whitespace-nowrap">{{ v.ts|date:"Y-m-d H:i" }}</td>
+          <td class="px-4 py-3 text-xs font-mono text-muted-foreground">{{ v.anonymous_id|truncatechars:12 }}</td>
+          <td class="px-4 py-3 text-sm text-muted-foreground hidden md:table-cell">
+            {% if v.user %}
+              <a href="/admin/accounts/user/{{ v.user.pk }}/change/" class="text-accent hover:underline">{{ v.user.email }}</a>
+            {% else %}
+              <span class="text-xs">anonymous</span>
+            {% endif %}
+          </td>
+          <td class="px-4 py-3 text-sm text-muted-foreground hidden md:table-cell font-mono">{{ v.path|truncatechars:30 }}</td>
+          <td class="px-4 py-3 text-xs text-muted-foreground hidden lg:table-cell">{{ v.referrer|truncatechars:40|default:"—" }}</td>
+          <td class="px-4 py-3 text-xs text-muted-foreground hidden lg:table-cell">{{ v.user_agent|truncatechars:40|default:"—" }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  {% if paginator.num_pages > 1 %}
+  <div class="mt-4 flex items-center justify-between text-sm">
+    <span class="text-muted-foreground">Page {{ visits_page.number }} of {{ paginator.num_pages }} ({{ paginator.count }} total)</span>
+    <div class="space-x-2">
+      {% if visits_page.has_previous %}
+      <a href="{{ page_link_prefix }}{{ visits_page.previous_page_number }}" class="text-accent hover:underline">Previous</a>
+      {% endif %}
+      {% if visits_page.has_next %}
+      <a href="{{ page_link_prefix }}{{ visits_page.next_page_number }}" class="text-accent hover:underline">Next</a>
+      {% endif %}
+    </div>
+  </div>
+  {% endif %}
+
+  {% else %}
+  <p class="text-sm text-muted-foreground">No visits captured for this link in this window.</p>
+  {% endif %}
+</div>
+
+{# Conversions table #}
+<div class="bg-card border border-border rounded-lg p-6">
+  <h2 class="text-lg font-semibold text-foreground mb-4">Signups &amp; conversions</h2>
+  {% if conversion_rows %}
+  <div class="overflow-x-auto">
+    <table class="w-full">
+      <thead class="bg-secondary">
+        <tr>
+          <th class="text-left px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">Email</th>
+          <th class="text-left px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">Signup</th>
+          <th class="text-left px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">Tier</th>
+          {% if has_conversion_data %}
+          <th class="text-left px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">Paid</th>
+          <th class="text-right px-4 py-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">MRR EUR</th>
+          {% endif %}
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-border">
+        {% for c in conversion_rows %}
+        <tr class="hover:bg-secondary/50 transition-colors">
+          <td class="px-4 py-3 text-sm text-foreground break-all">{{ c.email }}</td>
+          <td class="px-4 py-3 text-sm text-muted-foreground whitespace-nowrap">{% if c.signup_ts %}{{ c.signup_ts|date:"Y-m-d H:i" }}{% else %}—{% endif %}</td>
+          <td class="px-4 py-3 text-sm text-muted-foreground">{{ c.tier.name|default:"—" }}</td>
+          {% if has_conversion_data %}
+          <td class="px-4 py-3 text-sm">
+            {% if c.paid %}
+              <span class="text-xs px-2 py-1 rounded-full bg-green-500/20 text-green-400">Paid</span>
+            {% else %}
+              <span class="text-xs px-2 py-1 rounded-full bg-secondary text-muted-foreground">Free</span>
+            {% endif %}
+          </td>
+          <td class="px-4 py-3 text-sm text-foreground text-right">{{ c.mrr|default:0 }}</td>
+          {% endif %}
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% else %}
+  <p class="text-sm text-muted-foreground">No signups attributed to this link yet.</p>
+  {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary

- Adds Studio UTM analytics dashboard (issue #196, the 5/5 of UTM tracking series)
- New `analytics/aggregations.py` provides reusable aggregation helpers over `LinkClick` and `UtmConversion`
- New Studio views: dashboard, campaign detail, link detail, with filters and KPIs

## Verification

- Tester verified all acceptance criteria: 56 new tests added (passing)
- Full suite: 3667 tests passing
- `ruff check .` clean
- 8 screenshots verified by tester (dashboard, campaign drill-down, link drill-down, filter states)
- PM approved

## Test plan

- [x] Unit tests for aggregations
- [x] Studio view tests (access control, filters, context data)
- [x] Full Django suite passes (`uv run python manage.py test --parallel`)
- [x] Lint clean (`uv run ruff check .`)

Closes #196