### PR TITLE
Studio: repo dropdown for new content source (#199)

### DIFF
--- a/integrations/services/github.py
+++ b/integrations/services/github.py
@@ -24,6 +24,7 @@ import jwt
 import requests
 import yaml
 from django.conf import settings
+from django.core.cache import cache
 from django.utils import timezone
 
 from integrations.config import get_config
@@ -35,6 +36,10 @@ IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg', '.ico'}
 CONTENT_EXTENSIONS = {'.md', '.yaml', '.yml'}
 
 GITHUB_API_BASE = 'https://api.github.com'
+
+# Cache key + TTL for the repositories accessible to the GitHub App installation.
+INSTALLATION_REPOS_CACHE_KEY = 'github_installation_repositories'
+INSTALLATION_REPOS_CACHE_TIMEOUT = 60  # seconds
 
 # Required frontmatter fields per content type
 REQUIRED_FIELDS = {
@@ -177,6 +182,80 @@ def generate_github_app_token():
         )
 
     return response.json()['token']
+
+
+def list_installation_repositories(force_refresh=False):
+    """List repositories accessible to the GitHub App installation.
+
+    Calls ``GET /installation/repositories`` using a freshly minted installation
+    token. Pages through results so all accessible repos are returned. The
+    response is cached briefly (``INSTALLATION_REPOS_CACHE_TIMEOUT`` seconds)
+    to avoid hammering the GitHub API when the Studio form is reopened.
+
+    Args:
+        force_refresh: If True, bypass the cache and re-fetch from GitHub.
+
+    Returns:
+        list[dict]: One entry per repo with keys
+            ``full_name`` (e.g. ``"AI-Shipping-Labs/content"``),
+            ``private`` (bool),
+            ``default_branch`` (str).
+        Sorted alphabetically by ``full_name`` (case-insensitive).
+
+    Raises:
+        GitHubSyncError: If credentials are missing or the API call fails.
+    """
+    if not force_refresh:
+        cached = cache.get(INSTALLATION_REPOS_CACHE_KEY)
+        if cached is not None:
+            return cached
+
+    token = generate_github_app_token()
+    headers = {
+        'Authorization': f'token {token}',
+        'Accept': 'application/vnd.github+json',
+    }
+
+    repos = []
+    page = 1
+    per_page = 100
+    # Hard upper bound on pages to avoid runaway loops on a misbehaving API.
+    max_pages = 20
+    while page <= max_pages:
+        response = requests.get(
+            f'{GITHUB_API_BASE}/installation/repositories',
+            headers=headers,
+            params={'per_page': per_page, 'page': page},
+            timeout=15,
+        )
+        if response.status_code != 200:
+            raise GitHubSyncError(
+                f'Failed to list installation repositories: '
+                f'{response.status_code} {response.text}'
+            )
+
+        payload = response.json()
+        page_repos = payload.get('repositories', []) or []
+        for repo in page_repos:
+            repos.append({
+                'full_name': repo.get('full_name', ''),
+                'private': bool(repo.get('private', False)),
+                'default_branch': repo.get('default_branch', '') or 'main',
+            })
+
+        if len(page_repos) < per_page:
+            break
+        page += 1
+
+    repos.sort(key=lambda r: r['full_name'].lower())
+
+    cache.set(INSTALLATION_REPOS_CACHE_KEY, repos, INSTALLATION_REPOS_CACHE_TIMEOUT)
+    return repos
+
+
+def clear_installation_repositories_cache():
+    """Drop the cached installation repository list so the next call re-fetches."""
+    cache.delete(INSTALLATION_REPOS_CACHE_KEY)
 
 
 def clone_or_pull_repo(repo_name, target_dir, is_private=False):

--- a/integrations/tests/test_list_installation_repos.py
+++ b/integrations/tests/test_list_installation_repos.py
@@ -1,0 +1,178 @@
+"""Tests for the GitHub App ``list_installation_repositories`` helper.
+
+Covers issue #199: Studio repo dropdown when registering a new content source.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+
+from integrations.services.github import (
+    INSTALLATION_REPOS_CACHE_KEY,
+    GitHubSyncError,
+    clear_installation_repositories_cache,
+    list_installation_repositories,
+)
+
+
+def _mock_repos_response(repos, status_code=200):
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = {'repositories': repos}
+    response.text = ''
+    return response
+
+
+@override_settings(
+    GITHUB_APP_ID='12345',
+    GITHUB_APP_PRIVATE_KEY='fake-key',
+    GITHUB_APP_INSTALLATION_ID='67890',
+)
+class ListInstallationRepositoriesTest(TestCase):
+    """Verify the repo-list helper used by the Studio dropdown."""
+
+    def setUp(self):
+        cache.clear()
+
+    def tearDown(self):
+        cache.clear()
+
+    @patch('integrations.services.github.generate_github_app_token',
+           return_value='tok')
+    @patch('integrations.services.github.requests.get')
+    def test_returns_full_name_private_default_branch(self, mock_get, mock_token):
+        mock_get.return_value = _mock_repos_response([
+            {
+                'full_name': 'AI-Shipping-Labs/content',
+                'private': True,
+                'default_branch': 'main',
+            },
+            {
+                'full_name': 'AI-Shipping-Labs/blog',
+                'private': False,
+                'default_branch': 'master',
+            },
+        ])
+
+        repos = list_installation_repositories()
+
+        # Sorted alphabetically (case-insensitive)
+        self.assertEqual(
+            [r['full_name'] for r in repos],
+            ['AI-Shipping-Labs/blog', 'AI-Shipping-Labs/content'],
+        )
+        blog = repos[0]
+        self.assertFalse(blog['private'])
+        self.assertEqual(blog['default_branch'], 'master')
+        content = repos[1]
+        self.assertTrue(content['private'])
+        self.assertEqual(content['default_branch'], 'main')
+
+    @patch('integrations.services.github.generate_github_app_token',
+           return_value='tok')
+    @patch('integrations.services.github.requests.get')
+    def test_uses_token_in_authorization_header(self, mock_get, mock_token):
+        mock_get.return_value = _mock_repos_response([])
+        list_installation_repositories()
+
+        call = mock_get.call_args
+        headers = call.kwargs.get('headers') or call[1].get('headers')
+        self.assertEqual(headers['Authorization'], 'token tok')
+        self.assertIn('installation/repositories', call.args[0])
+
+    @patch('integrations.services.github.generate_github_app_token',
+           return_value='tok')
+    @patch('integrations.services.github.requests.get')
+    def test_caches_result_for_subsequent_calls(self, mock_get, mock_token):
+        mock_get.return_value = _mock_repos_response([
+            {'full_name': 'x/y', 'private': False, 'default_branch': 'main'},
+        ])
+
+        list_installation_repositories()
+        list_installation_repositories()
+        list_installation_repositories()
+
+        # GitHub API should only be hit once thanks to the cache
+        self.assertEqual(mock_get.call_count, 1)
+
+    @patch('integrations.services.github.generate_github_app_token',
+           return_value='tok')
+    @patch('integrations.services.github.requests.get')
+    def test_force_refresh_bypasses_cache(self, mock_get, mock_token):
+        mock_get.return_value = _mock_repos_response([
+            {'full_name': 'x/y', 'private': False, 'default_branch': 'main'},
+        ])
+
+        list_installation_repositories()
+        list_installation_repositories(force_refresh=True)
+
+        self.assertEqual(mock_get.call_count, 2)
+
+    @patch('integrations.services.github.generate_github_app_token',
+           return_value='tok')
+    @patch('integrations.services.github.requests.get')
+    def test_clear_cache_helper_drops_entry(self, mock_get, mock_token):
+        mock_get.return_value = _mock_repos_response([
+            {'full_name': 'x/y', 'private': False, 'default_branch': 'main'},
+        ])
+        list_installation_repositories()
+        self.assertIsNotNone(cache.get(INSTALLATION_REPOS_CACHE_KEY))
+
+        clear_installation_repositories_cache()
+
+        self.assertIsNone(cache.get(INSTALLATION_REPOS_CACHE_KEY))
+
+    @patch('integrations.services.github.generate_github_app_token',
+           return_value='tok')
+    @patch('integrations.services.github.requests.get')
+    def test_paginates_when_full_page_returned(self, mock_get, mock_token):
+        # First page returns a full 100 entries -> helper requests page 2
+        page1_repos = [
+            {'full_name': f'org/repo{i:03d}', 'private': False,
+             'default_branch': 'main'}
+            for i in range(100)
+        ]
+        page2_repos = [
+            {'full_name': 'org/last', 'private': True,
+             'default_branch': 'main'},
+        ]
+        mock_get.side_effect = [
+            _mock_repos_response(page1_repos),
+            _mock_repos_response(page2_repos),
+        ]
+
+        repos = list_installation_repositories()
+
+        self.assertEqual(mock_get.call_count, 2)
+        self.assertEqual(len(repos), 101)
+
+    @patch('integrations.services.github.generate_github_app_token',
+           return_value='tok')
+    @patch('integrations.services.github.requests.get')
+    def test_raises_github_sync_error_on_non_200(self, mock_get, mock_token):
+        response = MagicMock()
+        response.status_code = 401
+        response.text = 'Bad credentials'
+        mock_get.return_value = response
+
+        with self.assertRaises(GitHubSyncError) as ctx:
+            list_installation_repositories()
+        self.assertIn('401', str(ctx.exception))
+
+    @override_settings(
+        GITHUB_APP_ID='',
+        GITHUB_APP_PRIVATE_KEY='',
+        GITHUB_APP_INSTALLATION_ID='',
+    )
+    def test_missing_credentials_propagates_error(self):
+        with self.assertRaises(GitHubSyncError):
+            list_installation_repositories()
+
+    @patch('integrations.services.github.generate_github_app_token',
+           return_value='tok')
+    @patch('integrations.services.github.requests.get')
+    def test_handles_empty_repository_list(self, mock_get, mock_token):
+        mock_get.return_value = _mock_repos_response([])
+        repos = list_installation_repositories()
+        self.assertEqual(repos, [])

--- a/studio/tests/test_content_source_create.py
+++ b/studio/tests/test_content_source_create.py
@@ -1,0 +1,337 @@
+"""Tests for the Studio "Add content source" form (issue #199)."""
+
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.test import Client, TestCase
+
+from integrations.models import ContentSource
+from integrations.services.github import (
+    INSTALLATION_REPOS_CACHE_KEY,
+    GitHubSyncError,
+)
+
+User = get_user_model()
+
+
+SAMPLE_REPOS = [
+    {
+        'full_name': 'AI-Shipping-Labs/blog',
+        'private': False,
+        'default_branch': 'main',
+    },
+    {
+        'full_name': 'AI-Shipping-Labs/content',
+        'private': True,
+        'default_branch': 'main',
+    },
+]
+
+
+class ContentSourceCreateViewTest(TestCase):
+    """The Studio form to register a new ContentSource via the GitHub App."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.staff = User.objects.create_user(
+            email='staff@test.com', password='testpass', is_staff=True,
+        )
+
+    def setUp(self):
+        cache.clear()
+        self.client = Client()
+        self.client.login(email='staff@test.com', password='testpass')
+
+    def tearDown(self):
+        cache.clear()
+
+    # -- access control ------------------------------------------------------
+
+    def test_anonymous_redirected_to_login(self):
+        client = Client()
+        response = client.get('/studio/content-sources/new/')
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('/accounts/login/', response['Location'])
+
+    def test_non_staff_user_gets_403(self):
+        User.objects.create_user(
+            email='member@test.com', password='testpass', is_staff=False,
+        )
+        client = Client()
+        client.login(email='member@test.com', password='testpass')
+        response = client.get('/studio/content-sources/new/')
+        self.assertEqual(response.status_code, 403)
+
+    # -- GET: rendering ------------------------------------------------------
+
+    @patch('studio.views.content_sources.list_installation_repositories',
+           return_value=SAMPLE_REPOS)
+    def test_get_renders_form_with_repo_dropdown(self, _mock_list):
+        response = self.client.get('/studio/content-sources/new/')
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'studio/content_sources/create.html')
+        # Each repo full_name appears in an <option value="...">
+        self.assertContains(
+            response,
+            'value="AI-Shipping-Labs/blog"',
+        )
+        self.assertContains(
+            response,
+            'value="AI-Shipping-Labs/content"',
+        )
+
+    @patch('studio.views.content_sources.list_installation_repositories',
+           return_value=SAMPLE_REPOS)
+    def test_get_renders_content_type_choices(self, _mock_list):
+        response = self.client.get('/studio/content-sources/new/')
+        self.assertContains(response, 'value="article"')
+        self.assertContains(response, 'value="course"')
+        self.assertContains(response, 'value="event"')
+
+    @patch('studio.views.content_sources.list_installation_repositories',
+           side_effect=GitHubSyncError('GitHub App credentials not configured.'),
+           )
+    def test_get_shows_error_when_github_not_configured(self, _mock_list):
+        response = self.client.get('/studio/content-sources/new/')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            'GitHub App credentials not configured',
+        )
+        # No repos listed in the dropdown beyond the placeholder option
+        self.assertNotContains(response, 'AI-Shipping-Labs/blog')
+
+    @patch('studio.views.content_sources.list_installation_repositories',
+           return_value=SAMPLE_REPOS)
+    def test_get_marks_private_repos_in_label(self, _mock_list):
+        response = self.client.get('/studio/content-sources/new/')
+        # The private repo's label should include "(private)"
+        self.assertContains(response, 'AI-Shipping-Labs/content (private)')
+
+    # -- POST: success -------------------------------------------------------
+
+    @patch('studio.views.content_sources.list_installation_repositories',
+           return_value=SAMPLE_REPOS)
+    def test_post_creates_content_source_and_redirects(self, _mock_list):
+        response = self.client.post('/studio/content-sources/new/', {
+            'repo_name': 'AI-Shipping-Labs/blog',
+            'content_type': 'article',
+            'content_path': 'blog/',
+            'webhook_secret': 'manual-secret-value',
+        })
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], '/studio/sync/')
+
+        source = ContentSource.objects.get(repo_name='AI-Shipping-Labs/blog')
+        self.assertEqual(source.content_type, 'article')
+        self.assertEqual(source.content_path, 'blog/')
+        self.assertEqual(source.webhook_secret, 'manual-secret-value')
+        # ``is_private`` is taken from the API, not from the form
+        self.assertFalse(source.is_private)
+
+    @patch('studio.views.content_sources.list_installation_repositories',
+           return_value=SAMPLE_REPOS)
+    def test_post_sets_is_private_from_api_for_private_repo(self, _mock_list):
+        self.client.post('/studio/content-sources/new/', {
+            'repo_name': 'AI-Shipping-Labs/content',
+            'content_type': 'event',
+            'content_path': '',
+            'webhook_secret': 'whsec-value',
+        })
+        source = ContentSource.objects.get(
+            repo_name='AI-Shipping-Labs/content',
+        )
+        self.assertTrue(source.is_private)
+
+    @patch('studio.views.content_sources.list_installation_repositories',
+           return_value=SAMPLE_REPOS)
+    def test_post_auto_generates_webhook_secret_when_blank(self, _mock_list):
+        self.client.post('/studio/content-sources/new/', {
+            'repo_name': 'AI-Shipping-Labs/blog',
+            'content_type': 'article',
+            'content_path': '',
+            'webhook_secret': '',
+        })
+        source = ContentSource.objects.get(repo_name='AI-Shipping-Labs/blog')
+        self.assertTrue(source.webhook_secret)
+        # secrets.token_urlsafe(32) yields >=32 chars
+        self.assertGreaterEqual(len(source.webhook_secret), 32)
+
+    @patch('studio.views.content_sources.list_installation_repositories',
+           return_value=SAMPLE_REPOS)
+    def test_post_default_content_path_is_empty_string(self, _mock_list):
+        self.client.post('/studio/content-sources/new/', {
+            'repo_name': 'AI-Shipping-Labs/blog',
+            'content_type': 'article',
+            'webhook_secret': 'x',
+        })
+        source = ContentSource.objects.get(repo_name='AI-Shipping-Labs/blog')
+        self.assertEqual(source.content_path, '')
+
+    # -- POST: validation ----------------------------------------------------
+
+    @patch('studio.views.content_sources.list_installation_repositories',
+           return_value=SAMPLE_REPOS)
+    def test_post_rejects_repo_not_in_installation(self, _mock_list):
+        response = self.client.post('/studio/content-sources/new/', {
+            'repo_name': 'evil-org/private-stuff',
+            'content_type': 'article',
+            'content_path': '',
+            'webhook_secret': '',
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(ContentSource.objects.filter(
+            repo_name='evil-org/private-stuff',
+        ).exists())
+        self.assertContains(
+            response,
+            'not accessible to the GitHub App installation',
+            status_code=400,
+        )
+
+    @patch('studio.views.content_sources.list_installation_repositories',
+           return_value=SAMPLE_REPOS)
+    def test_post_rejects_invalid_content_type(self, _mock_list):
+        response = self.client.post('/studio/content-sources/new/', {
+            'repo_name': 'AI-Shipping-Labs/blog',
+            'content_type': 'not-a-real-type',
+            'content_path': '',
+            'webhook_secret': '',
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(ContentSource.objects.exists())
+
+    @patch('studio.views.content_sources.list_installation_repositories',
+           return_value=SAMPLE_REPOS)
+    def test_post_rejects_missing_repo(self, _mock_list):
+        response = self.client.post('/studio/content-sources/new/', {
+            'repo_name': '',
+            'content_type': 'article',
+            'content_path': '',
+            'webhook_secret': '',
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(ContentSource.objects.exists())
+
+    @patch('studio.views.content_sources.list_installation_repositories',
+           return_value=SAMPLE_REPOS)
+    def test_post_rejects_duplicate_repo_plus_content_type(self, _mock_list):
+        ContentSource.objects.create(
+            repo_name='AI-Shipping-Labs/blog',
+            content_type='article',
+        )
+        response = self.client.post('/studio/content-sources/new/', {
+            'repo_name': 'AI-Shipping-Labs/blog',
+            'content_type': 'article',
+            'content_path': '',
+            'webhook_secret': '',
+        })
+        self.assertEqual(response.status_code, 400)
+        # Still only one row
+        self.assertEqual(
+            ContentSource.objects.filter(
+                repo_name='AI-Shipping-Labs/blog',
+                content_type='article',
+            ).count(),
+            1,
+        )
+
+    @patch('studio.views.content_sources.list_installation_repositories',
+           side_effect=GitHubSyncError('boom'))
+    def test_post_rejects_when_github_api_unreachable(self, _mock_list):
+        response = self.client.post('/studio/content-sources/new/', {
+            'repo_name': 'AI-Shipping-Labs/blog',
+            'content_type': 'article',
+            'content_path': '',
+            'webhook_secret': '',
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(ContentSource.objects.exists())
+
+
+class ContentSourceRefreshViewTest(TestCase):
+    """The "Refresh repo list" button drops the cached entry."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.staff = User.objects.create_user(
+            email='staff@test.com', password='testpass', is_staff=True,
+        )
+
+    def setUp(self):
+        cache.clear()
+        self.client = Client()
+        self.client.login(email='staff@test.com', password='testpass')
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_refresh_clears_cache_and_redirects_to_form(self):
+        cache.set(INSTALLATION_REPOS_CACHE_KEY, [{'full_name': 'cached/repo'}])
+        response = self.client.post('/studio/content-sources/refresh/')
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], '/studio/content-sources/new/')
+        self.assertIsNone(cache.get(INSTALLATION_REPOS_CACHE_KEY))
+
+    def test_refresh_requires_post(self):
+        response = self.client.get('/studio/content-sources/refresh/')
+        self.assertEqual(response.status_code, 405)
+
+    def test_refresh_requires_staff(self):
+        client = Client()
+        response = client.post('/studio/content-sources/refresh/')
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('/accounts/login/', response['Location'])
+
+    def test_refresh_non_staff_gets_403(self):
+        User.objects.create_user(
+            email='member@test.com', password='testpass', is_staff=False,
+        )
+        client = Client()
+        client.login(email='member@test.com', password='testpass')
+        response = client.post('/studio/content-sources/refresh/')
+        self.assertEqual(response.status_code, 403)
+
+
+class SyncDashboardLinksToCreateTest(TestCase):
+    """The sync dashboard exposes the new "Add content source" entry point."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.staff = User.objects.create_user(
+            email='staff@test.com', password='testpass', is_staff=True,
+        )
+
+    def setUp(self):
+        self.client = Client()
+        self.client.login(email='staff@test.com', password='testpass')
+
+    def test_dashboard_has_link_to_add_form(self):
+        response = self.client.get('/studio/sync/')
+        self.assertContains(response, '/studio/content-sources/new/')
+        self.assertContains(response, 'Add content source')
+
+
+class AdminContentSourceFormUntouchedTest(TestCase):
+    """The Django admin form for ContentSource still works as before."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin = User.objects.create_superuser(
+            email='admin@test.com', password='testpass',
+        )
+
+    def setUp(self):
+        self.client = Client()
+        self.client.login(email='admin@test.com', password='testpass')
+
+    def test_admin_changelist_loads(self):
+        response = self.client.get('/admin/integrations/contentsource/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_admin_add_form_loads_without_github_app(self):
+        # No mocks, no GitHub creds: the admin form must still load because
+        # power users can fall back to free-text entry.
+        response = self.client.get('/admin/integrations/contentsource/add/')
+        self.assertEqual(response.status_code, 200)

--- a/studio/urls.py
+++ b/studio/urls.py
@@ -3,6 +3,10 @@ from django.urls import path
 from studio.views.announcement import announcement_banner_edit
 from studio.views.articles import article_edit, article_list
 from studio.views.campaigns import campaign_create, campaign_detail, campaign_list
+from studio.views.content_sources import (
+    content_source_create,
+    content_source_refresh,
+)
 from studio.views.courses import (
     course_access_grant,
     course_access_list,
@@ -189,4 +193,16 @@ urlpatterns = [
     path('sync/history/', sync_history, name='studio_sync_history'),
     path('sync/<uuid:source_id>/trigger/', sync_trigger, name='studio_sync_trigger'),
     path('sync/<uuid:source_id>/status/', sync_status, name='studio_sync_status'),
+
+    # Content Sources (register a new repo)
+    path(
+        'content-sources/new/',
+        content_source_create,
+        name='studio_content_source_create',
+    ),
+    path(
+        'content-sources/refresh/',
+        content_source_refresh,
+        name='studio_content_source_refresh',
+    ),
 ]

--- a/studio/views/content_sources.py
+++ b/studio/views/content_sources.py
@@ -1,0 +1,180 @@
+"""Studio views for registering ContentSource records via the GitHub App.
+
+Provides a guided form that:
+- Pulls the list of repositories the GitHub App installation can access and
+  shows them in a dropdown (no free-text typos).
+- Lets the admin pick the content type and an optional subdirectory.
+- Auto-fills ``is_private`` from the GitHub API response and auto-generates a
+  ``webhook_secret`` when one is not supplied.
+
+The Django admin form for ``ContentSource`` is intentionally left unchanged so
+power users can still register sources without GitHub App credentials.
+"""
+
+import logging
+import secrets
+
+from django.contrib import messages
+from django.shortcuts import redirect, render
+from django.urls import reverse
+from django.views.decorators.http import require_POST
+
+from integrations.models import ContentSource
+from integrations.models.content_source import CONTENT_TYPE_CHOICES
+from integrations.services.github import (
+    GitHubSyncError,
+    clear_installation_repositories_cache,
+    list_installation_repositories,
+)
+from studio.decorators import staff_required
+
+logger = logging.getLogger(__name__)
+
+
+def _load_repos(force_refresh=False):
+    """Return ``(repos, error)``: repos may be empty when the API fails."""
+    try:
+        repos = list_installation_repositories(force_refresh=force_refresh)
+        return repos, None
+    except GitHubSyncError as exc:
+        logger.warning('Could not fetch installation repositories: %s', exc)
+        return [], str(exc)
+
+
+def _render_form(request, *, selected_repo='', content_type='', content_path='',
+                 webhook_secret='', force_refresh=False, status=200):
+    repos, repo_error = _load_repos(force_refresh=force_refresh)
+    context = {
+        'repos': repos,
+        'repo_error': repo_error,
+        'content_type_choices': CONTENT_TYPE_CHOICES,
+        'selected_repo': selected_repo,
+        'selected_content_type': content_type,
+        'content_path': content_path,
+        'webhook_secret': webhook_secret,
+    }
+    return render(
+        request,
+        'studio/content_sources/create.html',
+        context,
+        status=status,
+    )
+
+
+@staff_required
+def content_source_create(request):
+    """Show / handle the "Add content source" form."""
+    if request.method == 'POST':
+        repo_name = (request.POST.get('repo_name') or '').strip()
+        content_type = (request.POST.get('content_type') or '').strip()
+        content_path = (request.POST.get('content_path') or '').strip()
+        webhook_secret = (request.POST.get('webhook_secret') or '').strip()
+
+        valid_content_types = {choice[0] for choice in CONTENT_TYPE_CHOICES}
+
+        if not repo_name:
+            messages.error(request, 'Pick a repository from the list.')
+            return _render_form(
+                request,
+                selected_repo=repo_name,
+                content_type=content_type,
+                content_path=content_path,
+                webhook_secret=webhook_secret,
+                status=400,
+            )
+
+        if content_type not in valid_content_types:
+            messages.error(request, 'Pick a valid content type.')
+            return _render_form(
+                request,
+                selected_repo=repo_name,
+                content_type=content_type,
+                content_path=content_path,
+                webhook_secret=webhook_secret,
+                status=400,
+            )
+
+        # Verify the repo really is accessible to the installation right now,
+        # and grab its private flag from the API instead of trusting the form.
+        repos, repo_error = _load_repos()
+        if repo_error:
+            messages.error(
+                request,
+                'Could not verify the repository against GitHub: '
+                f'{repo_error}',
+            )
+            return _render_form(
+                request,
+                selected_repo=repo_name,
+                content_type=content_type,
+                content_path=content_path,
+                webhook_secret=webhook_secret,
+                status=400,
+            )
+
+        match = next(
+            (r for r in repos if r['full_name'] == repo_name),
+            None,
+        )
+        if match is None:
+            messages.error(
+                request,
+                f"Repository '{repo_name}' is not accessible to the GitHub App "
+                "installation. Click 'Refresh repo list' if you just granted "
+                "access.",
+            )
+            return _render_form(
+                request,
+                selected_repo=repo_name,
+                content_type=content_type,
+                content_path=content_path,
+                webhook_secret=webhook_secret,
+                status=400,
+            )
+
+        is_private = match['private']
+
+        if ContentSource.objects.filter(
+            repo_name=repo_name, content_type=content_type,
+        ).exists():
+            messages.error(
+                request,
+                f"A content source for '{repo_name}' with content type "
+                f"'{content_type}' already exists.",
+            )
+            return _render_form(
+                request,
+                selected_repo=repo_name,
+                content_type=content_type,
+                content_path=content_path,
+                webhook_secret=webhook_secret,
+                status=400,
+            )
+
+        if not webhook_secret:
+            webhook_secret = secrets.token_urlsafe(32)
+
+        source = ContentSource.objects.create(
+            repo_name=repo_name,
+            content_type=content_type,
+            content_path=content_path,
+            webhook_secret=webhook_secret,
+            is_private=is_private,
+        )
+        messages.success(
+            request,
+            f"Content source registered: {source.repo_name} "
+            f"({source.content_type}).",
+        )
+        return redirect('studio_sync_dashboard')
+
+    return _render_form(request)
+
+
+@staff_required
+@require_POST
+def content_source_refresh(request):
+    """Drop the cached repo list and reload the form with fresh data."""
+    clear_installation_repositories_cache()
+    messages.success(request, 'Repository list refreshed from GitHub.')
+    return redirect(reverse('studio_content_source_create'))

--- a/templates/studio/content_sources/create.html
+++ b/templates/studio/content_sources/create.html
@@ -1,0 +1,128 @@
+{% extends "studio/base.html" %}
+
+{% block studio_title %}Add Content Source{% endblock %}
+
+{% block studio_content %}
+<div class="mb-8">
+  <a href="{% url 'studio_sync_dashboard' %}" class="text-sm text-muted-foreground hover:text-foreground transition-colors">
+    &larr; Back to Content Sync
+  </a>
+  <h1 class="text-2xl font-semibold text-foreground mt-2">Add Content Source</h1>
+  <p class="text-muted-foreground mt-1">
+    Register a new GitHub repository for content sync. Pick from the list of
+    repositories the GitHub App installation already has access to.
+  </p>
+</div>
+
+{% if messages %}
+<div class="mb-6 space-y-2">
+  {% for message in messages %}
+  <div class="px-4 py-3 rounded-lg text-sm {% if message.tags == 'error' %}bg-red-500/20 text-red-400{% elif message.tags == 'success' %}bg-green-500/20 text-green-400{% else %}bg-blue-500/20 text-blue-400{% endif %}">
+    {{ message }}
+  </div>
+  {% endfor %}
+</div>
+{% endif %}
+
+{% if repo_error %}
+<div class="mb-6 p-4 rounded-lg bg-red-500/10 border border-red-500/20 text-sm text-red-300">
+  <p class="font-medium text-red-400 mb-1">Could not fetch repository list from GitHub.</p>
+  <p class="font-mono text-xs">{{ repo_error }}</p>
+  <p class="mt-2">
+    Configure the GitHub App credentials under
+    <a href="{% url 'studio_settings' %}" class="underline hover:text-red-200">Settings</a>
+    and try again.
+  </p>
+</div>
+{% endif %}
+
+<div class="bg-card border border-border rounded-lg p-6 max-w-2xl">
+  <form method="post" action="{% url 'studio_content_source_create' %}">
+    {% csrf_token %}
+
+    <div class="mb-6">
+      <div class="flex items-center justify-between mb-1">
+        <label for="id_repo_name" class="block text-sm font-medium text-foreground">Repository</label>
+        <span class="text-xs text-muted-foreground">{{ repos|length }} accessible</span>
+      </div>
+      <select id="id_repo_name" name="repo_name" required
+              class="w-full bg-secondary border border-border rounded-lg px-4 py-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-accent">
+        <option value="">-- Select a repository --</option>
+        {% for repo in repos %}
+        <option value="{{ repo.full_name }}"
+                data-private="{% if repo.private %}1{% else %}0{% endif %}"
+                {% if repo.full_name == selected_repo %}selected{% endif %}>
+          {{ repo.full_name }}{% if repo.private %} (private){% endif %}
+        </option>
+        {% endfor %}
+      </select>
+      <p class="text-xs text-muted-foreground mt-1">
+        Don't see your repo? Grant the GitHub App access to it on GitHub, then
+        click "Refresh repo list" below.
+      </p>
+    </div>
+
+    <div class="mb-6">
+      <label for="id_content_type" class="block text-sm font-medium text-foreground mb-1">Content Type</label>
+      <select id="id_content_type" name="content_type" required
+              class="w-full bg-secondary border border-border rounded-lg px-4 py-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-accent">
+        <option value="">-- Select a content type --</option>
+        {% for value, label in content_type_choices %}
+        <option value="{{ value }}" {% if value == selected_content_type %}selected{% endif %}>
+          {{ label }}
+        </option>
+        {% endfor %}
+      </select>
+      <p class="text-xs text-muted-foreground mt-1">
+        Determines how the repo's files are parsed during sync.
+      </p>
+    </div>
+
+    <div class="mb-6">
+      <label for="id_content_path" class="block text-sm font-medium text-foreground mb-1">Content Path</label>
+      <input type="text" id="id_content_path" name="content_path"
+             value="{{ content_path }}" placeholder="e.g. blog/ (leave empty for repo root)"
+             class="w-full bg-secondary border border-border rounded-lg px-4 py-2 text-sm text-foreground placeholder-muted-foreground focus:outline-none focus:ring-1 focus:ring-accent">
+      <p class="text-xs text-muted-foreground mt-1">
+        Subdirectory within the repo to sync from. Leave empty to sync from the
+        repo root.
+      </p>
+    </div>
+
+    <div class="mb-6">
+      <label for="id_webhook_secret" class="block text-sm font-medium text-foreground mb-1">Webhook Secret</label>
+      <input type="text" id="id_webhook_secret" name="webhook_secret"
+             value="{{ webhook_secret }}" placeholder="Leave blank to auto-generate"
+             class="w-full bg-secondary border border-border rounded-lg px-4 py-2 text-sm text-foreground placeholder-muted-foreground focus:outline-none focus:ring-1 focus:ring-accent font-mono">
+      <p class="text-xs text-muted-foreground mt-1">
+        Used to validate GitHub webhook signatures. Leave blank and we'll
+        generate a secure random one. You'll need to paste it into GitHub when
+        you set up the webhook for this repo.
+      </p>
+    </div>
+
+    <div class="flex items-center gap-3">
+      <button type="submit"
+              class="bg-accent text-accent-foreground px-6 py-2 rounded-lg text-sm font-medium hover:opacity-90 transition-opacity">
+        Add Content Source
+      </button>
+      <a href="{% url 'studio_sync_dashboard' %}" class="text-sm text-muted-foreground hover:text-foreground transition-colors">
+        Cancel
+      </a>
+    </div>
+  </form>
+
+  <form method="post" action="{% url 'studio_content_source_refresh' %}" class="mt-6 pt-6 border-t border-border">
+    {% csrf_token %}
+    <button type="submit"
+            class="text-sm text-muted-foreground hover:text-foreground transition-colors inline-flex items-center gap-2">
+      <i data-lucide="refresh-cw" class="w-4 h-4"></i>
+      Refresh repo list
+    </button>
+    <p class="text-xs text-muted-foreground mt-1">
+      The list is cached for ~60 seconds. Click this if you just granted the
+      GitHub App access to a new repo.
+    </p>
+  </form>
+</div>
+{% endblock %}

--- a/templates/studio/sync/dashboard.html
+++ b/templates/studio/sync/dashboard.html
@@ -9,6 +9,10 @@
     <p class="text-muted-foreground mt-1">Sync content from GitHub repositories.</p>
   </div>
   <div class="flex items-center gap-3 shrink-0">
+    <a href="{% url 'studio_content_source_create' %}"
+       class="px-4 py-2 text-sm text-muted-foreground hover:text-foreground border border-border rounded-lg hover:bg-secondary transition-colors">
+      Add content source
+    </a>
     <a href="{% url 'studio_sync_history' %}"
        class="px-4 py-2 text-sm text-muted-foreground hover:text-foreground border border-border rounded-lg hover:bg-secondary transition-colors">
       History
@@ -199,7 +203,10 @@
 {% else %}
 <div class="bg-card border border-border rounded-lg p-12 text-center">
   <p class="text-muted-foreground">No content sources configured.</p>
-  <p class="text-sm text-muted-foreground mt-1">Add content sources in Django admin or run <code class="bg-secondary px-1.5 py-0.5 rounded text-xs">manage.py seed_content_sources</code>.</p>
+  <p class="text-sm text-muted-foreground mt-1">
+    <a href="{% url 'studio_content_source_create' %}" class="text-accent hover:underline">Add a content source</a>,
+    use Django admin, or run <code class="bg-secondary px-1.5 py-0.5 rounded text-xs">manage.py seed_content_sources</code>.
+  </p>
 </div>
 {% endif %}
 


### PR DESCRIPTION
## Summary
- Adds a Studio flow to create a `ContentSource` by selecting a repo from a dropdown populated by the GitHub App installation.
- New view, template, and URL route under `/studio/content-sources/new/`, plus a helper on the GitHub service to list installation repos.

## Test plan
- [x] Unit tests: 31 new tests (`integrations/tests/test_list_installation_repos.py`, `studio/tests/test_content_source_create.py`)
- [x] Tester captured 4 screenshots of the new flow
- [x] Full test suite: 3698 tests passing
- [x] `uv run ruff check .` clean

Closes #199

Generated with [Claude Code](https://claude.com/claude-code)