### PR TITLE
Course sync: ignore patterns + README handling (#200)

### DIFF
--- a/integrations/services/github.py
+++ b/integrations/services/github.py
@@ -17,6 +17,8 @@ import shutil
 import subprocess
 import tempfile
 import time
+import uuid
+from pathlib import PurePath
 
 import boto3
 import frontmatter
@@ -74,6 +76,49 @@ def derive_slug(name):
     stem = name.rsplit('.', 1)[0] if '.' in name else name
     match = re.match(r'^\d+-(.+)', stem)
     return match.group(1) if match else stem
+
+
+def _matches_ignore_patterns(rel_path, patterns):
+    """Return True if ``rel_path`` matches any glob in ``patterns``.
+
+    Uses :meth:`pathlib.PurePath.full_match` (Python 3.13+) so recursive
+    ``**`` globs work as expected. ``rel_path`` must be relative to whichever
+    directory the ignore patterns were declared against (course root for
+    course-level ``ignore:``, module dir for module-level).
+    """
+    if not patterns:
+        return False
+    p = PurePath(rel_path)
+    for pattern in patterns:
+        if not pattern:
+            continue
+        try:
+            if p.full_match(pattern):
+                return True
+        except (ValueError, TypeError):
+            # Malformed glob – treat as non-matching rather than blowing up sync.
+            continue
+    return False
+
+
+def _extract_readme_title(body, fallback):
+    """Return the first Markdown H1 heading in ``body`` or ``fallback``."""
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped.startswith('# ') and not stripped.startswith('## '):
+            return stripped[2:].strip() or fallback
+    return fallback
+
+
+def _derive_readme_content_id(repo_name, module_source_path):
+    """Derive a stable UUIDv5 content_id for a module's README-as-unit.
+
+    Used when the README has no explicit ``content_id`` in frontmatter. The
+    namespace key combines the repo name and module source path so the UUID is
+    stable across syncs and unique across modules/repos.
+    """
+    key = f'{repo_name}:{module_source_path}:readme'
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, key))
 
 
 class GitHubSyncError(Exception):
@@ -1039,6 +1084,12 @@ def _sync_single_course(
 
     Used by both multi-course mode (each child dir is its own course) and
     single-course mode (the resolved content_dir is the course root).
+
+    Respects ``ignore:`` in ``course.yaml`` (a list of globs relative to the
+    course root) — matched files are skipped everywhere in the course. If no
+    ``description:`` is set in ``course.yaml`` and ``README.md`` exists at the
+    course root and is not ignored, the README body becomes the course
+    description.
     """
     from content.models import Course
 
@@ -1074,9 +1125,35 @@ def _sync_single_course(
 
         seen_course_slugs.add(slug)
 
+        # Course-level ignore globs (relative to course_dir). Applied to every
+        # module via _sync_course_modules.
+        raw_ignore = course_data.get('ignore', []) or []
+        course_ignore_patterns = [str(p) for p in raw_ignore]
+
+        # Description: explicit `description:` wins; otherwise fall back to
+        # README.md at the course root if present and not ignored.
+        description = course_data.get('description', '') or ''
+        if not description:
+            readme_path = os.path.join(course_dir, 'README.md')
+            if (
+                os.path.isfile(readme_path)
+                and not _matches_ignore_patterns(
+                    'README.md', course_ignore_patterns,
+                )
+            ):
+                try:
+                    _, readme_body = _parse_markdown_file(readme_path)
+                    if readme_body and readme_body.strip():
+                        description = readme_body
+                except Exception as e:
+                    logger.warning(
+                        'Failed to read course README at %s: %s',
+                        readme_path, e,
+                    )
+
         course_defaults = {
             'title': course_data.get('title', slug),
-            'description': course_data.get('description', ''),
+            'description': description,
             'instructor_name': course_data.get('instructor_name', ''),
             'instructor_bio': course_data.get('instructor_bio', ''),
             'cover_image_url': rewrite_cover_image_url(
@@ -1115,6 +1192,7 @@ def _sync_single_course(
         _sync_course_modules(
             course, course_dir, repo_dir, source.repo_name,
             commit_sha, stats, known_images=known_images,
+            course_ignore_patterns=course_ignore_patterns,
         )
 
     except Exception as e:
@@ -1199,14 +1277,27 @@ def _sync_courses(source, repo_dir, commit_sha, sync_log, known_images=None):
 
 
 def _sync_course_modules(course, course_dir, repo_dir, repo_name, commit_sha, stats,
-                         known_images=None):
-    """Sync modules and units for a course."""
+                         known_images=None, course_ignore_patterns=None):
+    """Sync modules and units for a course.
+
+    ``course_ignore_patterns`` are globs relative to ``course_dir`` from the
+    course-level ``ignore:`` key. A directory whose path matches is skipped
+    entirely. The patterns are also passed down to unit sync so individual
+    files matched at the course level are skipped wherever they appear.
+    """
     from content.models import Module
 
+    course_ignore_patterns = course_ignore_patterns or []
     seen_module_paths = set()
 
     for entry in sorted(os.scandir(course_dir), key=lambda e: e.name):
         if not entry.is_dir() or entry.name.startswith('.') or entry.name == 'images':
+            continue
+
+        # Skip whole module dirs that match course-level ignore globs
+        # (e.g. `docs/**` ignores the docs/ directory in addition to its files).
+        dir_rel_to_course = os.path.relpath(entry.path, course_dir)
+        if _matches_ignore_patterns(dir_rel_to_course, course_ignore_patterns):
             continue
 
         module_yaml_path = os.path.join(entry.path, 'module.yaml')
@@ -1244,10 +1335,18 @@ def _sync_course_modules(course, course_dir, repo_dir, repo_name, commit_sha, st
             else:
                 stats['updated'] += 1
 
+            # Module-level ignore patterns (relative to module dir). Course
+            # patterns are translated/filtered separately in _sync_module_units.
+            raw_module_ignore = module_data.get('ignore', []) or []
+            module_ignore_patterns = [str(p) for p in raw_module_ignore]
+
             # Sync units within this module
             _sync_module_units(
                 module, entry.path, repo_dir, repo_name, commit_sha, stats,
                 known_images=known_images,
+                course_dir=course_dir,
+                course_ignore_patterns=course_ignore_patterns,
+                module_ignore_patterns=module_ignore_patterns,
             )
 
         except Exception as e:
@@ -1267,16 +1366,117 @@ def _sync_course_modules(course, course_dir, repo_dir, repo_name, commit_sha, st
 
 
 def _sync_module_units(module, module_dir, repo_dir, repo_name, commit_sha, stats,
-                       known_images=None):
-    """Sync units (markdown files) within a module directory."""
+                       known_images=None, course_dir=None,
+                       course_ignore_patterns=None,
+                       module_ignore_patterns=None):
+    """Sync units (markdown files) within a module directory.
+
+    ``course_ignore_patterns`` are globs relative to ``course_dir`` (course
+    root). ``module_ignore_patterns`` are globs relative to ``module_dir``.
+    Files matched by either list are skipped.
+
+    README.md at the module root is promoted to the first unit of the module
+    (``sort_order = -1``) unless it is ignored by either list.
+    """
     from content.models import Unit, UserCourseProgress
+
+    course_ignore_patterns = course_ignore_patterns or []
+    module_ignore_patterns = module_ignore_patterns or []
+    # course_dir defaults to module_dir's parent when not supplied so callers
+    # that pre-date this signature still work (course-level patterns become
+    # no-ops in that case because course_ignore_patterns is empty).
+    if course_dir is None:
+        course_dir = os.path.dirname(module_dir)
 
     seen_unit_paths = set()
     # Track newly created units with their hashes for rename detection
     new_unit_hashes = {}
 
+    def _is_ignored(filename):
+        """Return True if the file is matched by any course- or module-level ignore glob."""
+        filepath = os.path.join(module_dir, filename)
+        rel_to_course = os.path.relpath(filepath, course_dir)
+        if _matches_ignore_patterns(rel_to_course, course_ignore_patterns):
+            return True
+        if _matches_ignore_patterns(filename, module_ignore_patterns):
+            return True
+        return False
+
+    # README at module root -> first unit (sort_order = -1) unless ignored.
+    readme_filename = None
+    for name in os.listdir(module_dir):
+        if name.lower() == 'readme.md':
+            readme_filename = name
+            break
+
+    if readme_filename and not _is_ignored(readme_filename):
+        readme_path = os.path.join(module_dir, readme_filename)
+        readme_rel = os.path.relpath(readme_path, repo_dir)
+        try:
+            metadata, body = _parse_markdown_file(readme_path)
+
+            # content_id: explicit frontmatter wins; otherwise derive a stable
+            # UUIDv5 from the module source path so we get idempotent upserts.
+            module_source_path = module.source_path or os.path.relpath(
+                module_dir, repo_dir,
+            )
+            readme_content_id = metadata.get('content_id') or (
+                _derive_readme_content_id(repo_name, module_source_path)
+            )
+
+            title = metadata.get('title') or _extract_readme_title(
+                body, fallback=module.title,
+            )
+
+            content_hash = _compute_content_hash(body)
+            base_dir = os.path.dirname(readme_rel)
+            if known_images is not None:
+                _check_broken_image_refs(
+                    body, readme_rel, repo_name, base_dir,
+                    known_images, stats.get('errors', []),
+                )
+            body = rewrite_image_urls(body, repo_name, base_dir)
+
+            readme_slug = metadata.get('slug', 'readme')
+            readme_sort_order = metadata.get('sort_order', -1)
+
+            readme_defaults = {
+                'title': title,
+                'slug': readme_slug,
+                'sort_order': readme_sort_order,
+                'video_url': metadata.get('video_url', ''),
+                'timestamps': metadata.get('timestamps', []),
+                'is_preview': metadata.get('is_preview', False),
+                'content_hash': content_hash,
+                'source_repo': repo_name,
+                'source_commit': commit_sha,
+                'content_id': readme_content_id,
+                'body': body,
+            }
+
+            unit, created = Unit.objects.update_or_create(
+                module=module,
+                source_path=readme_rel,
+                defaults=readme_defaults,
+            )
+            seen_unit_paths.add(readme_rel)
+            if created:
+                stats['created'] += 1
+                new_unit_hashes[content_hash] = unit
+            else:
+                stats['updated'] += 1
+        except Exception as e:
+            stats['errors'].append({
+                'file': readme_rel,
+                'error': str(e),
+            })
+
     for filename in sorted(os.listdir(module_dir)):
         if not filename.endswith('.md') or filename.upper() == 'README.MD':
+            continue
+
+        # Respect course- and module-level ignore globs.
+        if _is_ignored(filename):
             continue
 
         filepath = os.path.join(module_dir, filename)

--- a/integrations/tests/test_course_ignore_readme.py
+++ b/integrations/tests/test_course_ignore_readme.py
@@ -1,0 +1,505 @@
+"""Tests for course sync: ignore patterns + README handling (issue #200).
+
+Covers:
+- ``ignore:`` in course.yaml is honored across modules (course-level)
+- ``ignore:`` in module.yaml is honored within that module (merges on top)
+- Recursive ``**`` globs (``**/*.template.md``, ``**/plan.md``, ``docs/**``)
+- Module-root README.md becomes the first unit (sort_order = -1)
+- Course-root README.md populates Course.description when no explicit
+  ``description:`` is set
+- Explicit ``description:`` in course.yaml overrides the README
+- README listed in ``ignore:`` is suppressed
+- Re-running the sync is idempotent (stable content_id, no churn)
+- Helper functions (_matches_ignore_patterns, _extract_readme_title,
+  _derive_readme_content_id)
+"""
+
+import os
+import shutil
+import tempfile
+import uuid
+
+from django.test import TestCase
+
+from content.models import Course, Module, Unit
+from integrations.models import ContentSource
+from integrations.services.github import (
+    _derive_readme_content_id,
+    _extract_readme_title,
+    _matches_ignore_patterns,
+    sync_content_source,
+)
+
+
+class MatchesIgnorePatternsTest(TestCase):
+    """Unit tests for the glob matcher used by course sync."""
+
+    def test_empty_patterns_never_match(self):
+        self.assertFalse(_matches_ignore_patterns('AGENTS.md', []))
+        self.assertFalse(_matches_ignore_patterns('AGENTS.md', None))
+
+    def test_literal_filename(self):
+        self.assertTrue(_matches_ignore_patterns('AGENTS.md', ['AGENTS.md']))
+        self.assertFalse(_matches_ignore_patterns('AGENT.md', ['AGENTS.md']))
+
+    def test_directory_recursive_glob(self):
+        self.assertTrue(_matches_ignore_patterns('docs/writing.md', ['docs/**']))
+        self.assertTrue(_matches_ignore_patterns('docs/sub/x.md', ['docs/**']))
+        self.assertFalse(_matches_ignore_patterns('other/writing.md', ['docs/**']))
+
+    def test_template_files_recursive(self):
+        self.assertTrue(_matches_ignore_patterns(
+            '01-intro/example.template.md', ['**/*.template.md'],
+        ))
+        self.assertTrue(_matches_ignore_patterns(
+            '02-basics/deep/x.template.md', ['**/*.template.md'],
+        ))
+        self.assertFalse(_matches_ignore_patterns(
+            '01-intro/example.md', ['**/*.template.md'],
+        ))
+
+    def test_plan_files_recursive(self):
+        self.assertTrue(_matches_ignore_patterns(
+            '01-intro/plan.md', ['**/plan.md'],
+        ))
+        self.assertFalse(_matches_ignore_patterns(
+            '01-intro/planning.md', ['**/plan.md'],
+        ))
+
+    def test_multiple_patterns_any_matches(self):
+        patterns = ['AGENTS.md', 'docs/**', '**/*.template.md']
+        self.assertTrue(_matches_ignore_patterns('AGENTS.md', patterns))
+        self.assertTrue(_matches_ignore_patterns('docs/x.md', patterns))
+        self.assertTrue(_matches_ignore_patterns('01/x.template.md', patterns))
+        self.assertFalse(_matches_ignore_patterns('01/real.md', patterns))
+
+    def test_malformed_glob_does_not_crash(self):
+        # Unsupported patterns just don't match; sync must keep going.
+        # (PurePath.full_match raises ValueError on e.g. empty patterns.)
+        self.assertFalse(_matches_ignore_patterns('x.md', ['']))
+
+
+class ExtractReadmeTitleTest(TestCase):
+    """Unit tests for pulling the H1 out of a README body."""
+
+    def test_first_h1_is_used(self):
+        body = '# Welcome to Python\n\nSome intro.\n## Subheading\n'
+        self.assertEqual(
+            _extract_readme_title(body, fallback='Fallback'),
+            'Welcome to Python',
+        )
+
+    def test_first_h1_wins_over_later_h1(self):
+        body = '# First\n\n# Second\n'
+        self.assertEqual(
+            _extract_readme_title(body, fallback='F'), 'First',
+        )
+
+    def test_no_h1_returns_fallback(self):
+        body = '## Only H2\n\nPlain text.\n'
+        self.assertEqual(
+            _extract_readme_title(body, fallback='Module Title'),
+            'Module Title',
+        )
+
+    def test_empty_body_returns_fallback(self):
+        self.assertEqual(
+            _extract_readme_title('', fallback='Module Title'),
+            'Module Title',
+        )
+
+
+class DeriveReadmeContentIdTest(TestCase):
+    """The derived UUID must be stable and distinct per module."""
+
+    def test_stable_across_calls(self):
+        a = _derive_readme_content_id('org/repo', '01-intro')
+        b = _derive_readme_content_id('org/repo', '01-intro')
+        self.assertEqual(a, b)
+        # Valid UUID string.
+        uuid.UUID(a)
+
+    def test_different_modules_get_different_ids(self):
+        a = _derive_readme_content_id('org/repo', '01-intro')
+        b = _derive_readme_content_id('org/repo', '02-basics')
+        self.assertNotEqual(a, b)
+
+    def test_different_repos_get_different_ids(self):
+        a = _derive_readme_content_id('org/repo', '01-intro')
+        b = _derive_readme_content_id('other/repo', '01-intro')
+        self.assertNotEqual(a, b)
+
+
+class _CourseSyncFixtureBase(TestCase):
+    """Helpers to write a realistic single-course repo on disk."""
+
+    def setUp(self):
+        self.source = ContentSource.objects.create(
+            repo_name='AI-Shipping-Labs/python-course',
+            content_type='course',
+            content_path='',
+        )
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _write(self, rel_path, text):
+        full = os.path.join(self.temp_dir, rel_path)
+        os.makedirs(os.path.dirname(full), exist_ok=True)
+        with open(full, 'w') as f:
+            f.write(text)
+        return full
+
+    def _write_root_course_yaml(self, extras=''):
+        body = (
+            'title: "Python Course"\n'
+            'slug: "python-course"\n'
+            'instructor_name: "Alexey Grigorev"\n'
+            'required_level: 20\n'
+            'is_free: false\n'
+            'content_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"\n'
+        ) + extras
+        self._write('course.yaml', body)
+
+    def _write_module_yaml(self, dirname, title, content_id, extras=''):
+        body = (
+            f'title: "{title}"\n'
+            f'content_id: "{content_id}"\n'
+        ) + extras
+        self._write(f'{dirname}/module.yaml', body)
+
+    def _write_unit(self, dirname, filename, title, content_id,
+                    body='Unit body.\n'):
+        text = (
+            '---\n'
+            f'title: "{title}"\n'
+            f'content_id: "{content_id}"\n'
+            '---\n'
+            f'{body}'
+        )
+        self._write(f'{dirname}/{filename}', text)
+
+
+class CourseRootReadmeAsDescriptionTest(_CourseSyncFixtureBase):
+    """Course-root README.md populates Course.description by default."""
+
+    def test_readme_becomes_description_when_no_explicit_description(self):
+        self._write_root_course_yaml()  # no description: key
+        self._write('README.md', '# Python Course\n\nWelcome to the course.\n')
+        self._write_module_yaml(
+            '01-intro', 'Intro', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        )
+        self._write_unit(
+            '01-intro', '01-why.md', 'Why', 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        )
+
+        log = sync_content_source(self.source, repo_dir=self.temp_dir)
+        self.assertEqual(log.errors, [])
+
+        course = Course.objects.get(slug='python-course')
+        self.assertIn('Welcome to the course.', course.description)
+        # Rendered HTML picks up the README heading.
+        self.assertIn('Python Course', course.description_html)
+
+    def test_explicit_description_overrides_readme(self):
+        self._write_root_course_yaml(
+            extras='description: "Explicit description from YAML."\n',
+        )
+        self._write('README.md', '# Ignored README\n\nThis should not win.\n')
+        self._write_module_yaml(
+            '01-intro', 'Intro', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        )
+        self._write_unit(
+            '01-intro', '01-why.md', 'Why',
+            'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        )
+
+        sync_content_source(self.source, repo_dir=self.temp_dir)
+        course = Course.objects.get(slug='python-course')
+        self.assertEqual(course.description, 'Explicit description from YAML.')
+        self.assertNotIn('Ignored README', course.description)
+
+    def test_readme_in_ignore_is_suppressed(self):
+        self._write_root_course_yaml(
+            extras='ignore:\n  - README.md\n',
+        )
+        self._write('README.md', '# Suppressed\n\nShould not appear.\n')
+        self._write_module_yaml(
+            '01-intro', 'Intro', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        )
+        self._write_unit(
+            '01-intro', '01-why.md', 'Why',
+            'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        )
+
+        sync_content_source(self.source, repo_dir=self.temp_dir)
+        course = Course.objects.get(slug='python-course')
+        self.assertEqual(course.description, '')
+
+    def test_missing_readme_leaves_description_empty(self):
+        self._write_root_course_yaml()
+        self._write_module_yaml(
+            '01-intro', 'Intro', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        )
+        self._write_unit(
+            '01-intro', '01-why.md', 'Why',
+            'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        )
+
+        sync_content_source(self.source, repo_dir=self.temp_dir)
+        course = Course.objects.get(slug='python-course')
+        self.assertEqual(course.description, '')
+
+
+class ModuleReadmeAsFirstUnitTest(_CourseSyncFixtureBase):
+    """Module-root README.md becomes the first unit of the module."""
+
+    def test_module_readme_becomes_first_unit(self):
+        self._write_root_course_yaml()
+        self._write_module_yaml(
+            '01-intro', 'Introduction',
+            'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        )
+        # Module README with an H1 distinct from the module title.
+        self._write(
+            '01-intro/README.md',
+            '# Getting Started With Python\n\nOverview of this module.\n',
+        )
+        # Two numbered units after it.
+        self._write_unit(
+            '01-intro', '01-why.md', 'Why Python',
+            'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        )
+        self._write_unit(
+            '01-intro', '02-setup.md', 'Setup',
+            'dddddddd-dddd-dddd-dddd-dddddddddddd',
+        )
+
+        log = sync_content_source(self.source, repo_dir=self.temp_dir)
+        self.assertEqual(log.errors, [])
+
+        module = Module.objects.get(course__slug='python-course')
+        units = list(Unit.objects.filter(module=module).order_by('sort_order'))
+        titles = [u.title for u in units]
+        self.assertEqual(
+            titles,
+            ['Getting Started With Python', 'Why Python', 'Setup'],
+        )
+        # First unit is the README and comes before the numbered units.
+        self.assertEqual(units[0].sort_order, -1)
+        self.assertEqual(units[0].slug, 'readme')
+        self.assertIn('Overview of this module.', units[0].body)
+
+    def test_module_readme_title_falls_back_to_module_title(self):
+        self._write_root_course_yaml()
+        self._write_module_yaml(
+            '01-intro', 'Introduction',
+            'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        )
+        # README without H1.
+        self._write('01-intro/README.md', 'No heading, just text.\n')
+
+        sync_content_source(self.source, repo_dir=self.temp_dir)
+        unit = Unit.objects.get(
+            module__course__slug='python-course', slug='readme',
+        )
+        self.assertEqual(unit.title, 'Introduction')
+
+    def test_module_readme_in_module_ignore_is_suppressed(self):
+        self._write_root_course_yaml()
+        self._write_module_yaml(
+            '01-intro', 'Intro',
+            'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+            extras='ignore:\n  - README.md\n',
+        )
+        self._write('01-intro/README.md', '# Should Be Skipped\n\nNope.\n')
+        self._write_unit(
+            '01-intro', '01-why.md', 'Why',
+            'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        )
+
+        sync_content_source(self.source, repo_dir=self.temp_dir)
+        module = Module.objects.get(course__slug='python-course')
+        slugs = set(Unit.objects.filter(module=module).values_list('slug', flat=True))
+        self.assertNotIn('readme', slugs)
+        self.assertEqual(slugs, {'why'})
+
+    def test_module_readme_content_id_is_stable_across_syncs(self):
+        self._write_root_course_yaml()
+        self._write_module_yaml(
+            '01-intro', 'Intro',
+            'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        )
+        self._write('01-intro/README.md', '# Intro\n\nFirst.\n')
+        self._write_unit(
+            '01-intro', '01-why.md', 'Why',
+            'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        )
+
+        sync_content_source(self.source, repo_dir=self.temp_dir)
+        first_unit = Unit.objects.get(slug='readme')
+        first_id = first_unit.content_id
+
+        # Run sync again - no churn.
+        sync_content_source(self.source, repo_dir=self.temp_dir)
+        self.assertEqual(Unit.objects.filter(slug='readme').count(), 1)
+        self.assertEqual(
+            Unit.objects.get(slug='readme').content_id, first_id,
+        )
+
+
+class CourseIgnorePatternsTest(_CourseSyncFixtureBase):
+    """Course-level ``ignore:`` is honored across all modules."""
+
+    def test_course_level_ignores_skip_matching_files(self):
+        self._write_root_course_yaml(
+            extras=(
+                'ignore:\n'
+                '  - AGENTS.md\n'
+                '  - docs/**\n'
+                '  - "**/*.template.md"\n'
+                '  - "**/plan.md"\n'
+            ),
+        )
+        # Ignored files at the course root
+        self._write('AGENTS.md', '# Agents\n\nInstructions for AI agents.\n')
+        self._write('docs/writing.md', '# Writing guide\n')
+        self._write('docs/style.md', '# Style guide\n')
+
+        # Module with legitimate content + ignored files.
+        self._write_module_yaml(
+            '01-intro', 'Intro',
+            'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        )
+        self._write_unit(
+            '01-intro', '01-why.md', 'Why',
+            'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        )
+        # Template scaffolding - must not become a unit.
+        self._write(
+            '01-intro/01-why.template.md',
+            '---\ntitle: "Template"\n---\nTEMPLATE body\n',
+        )
+        # Author's plan file - must not become a unit.
+        self._write(
+            '01-intro/plan.md',
+            '---\ntitle: "Plan"\n---\nAuthor notes.\n',
+        )
+
+        log = sync_content_source(self.source, repo_dir=self.temp_dir)
+        # No errors about missing content_id on ignored files.
+        self.assertEqual(log.errors, [])
+
+        # Only the one real unit exists.
+        course = Course.objects.get(slug='python-course')
+        module = Module.objects.get(course=course)
+        unit_slugs = set(
+            Unit.objects.filter(module=module).values_list('slug', flat=True),
+        )
+        # Must not include template/plan files.
+        self.assertNotIn('why.template', unit_slugs)
+        self.assertNotIn('plan', unit_slugs)
+        # Only 'why' is present.
+        self.assertEqual(unit_slugs, {'why'})
+
+    def test_ignored_docs_dir_is_not_synced_as_module(self):
+        """Directory matched by ``docs/**`` is skipped even if it has files."""
+        self._write_root_course_yaml(extras='ignore:\n  - docs/**\n')
+        # docs/ would never be a module (no module.yaml) but verify nothing
+        # gets walked.
+        self._write('docs/writing.md', '# Writing\n')
+        self._write_module_yaml(
+            '01-intro', 'Intro',
+            'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        )
+        self._write_unit(
+            '01-intro', '01-why.md', 'Why',
+            'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        )
+
+        log = sync_content_source(self.source, repo_dir=self.temp_dir)
+        self.assertEqual(log.errors, [])
+        # Exactly one module was synced.
+        course = Course.objects.get(slug='python-course')
+        self.assertEqual(Module.objects.filter(course=course).count(), 1)
+
+
+class ModuleIgnoreMergesWithCourseTest(_CourseSyncFixtureBase):
+    """Module-level ignore patterns are additive to course-level."""
+
+    def test_module_ignore_suppresses_only_its_module(self):
+        self._write_root_course_yaml()
+        # Module 1: suppresses README via module.yaml ignore.
+        self._write_module_yaml(
+            '01-intro', 'Intro',
+            'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+            extras='ignore:\n  - README.md\n',
+        )
+        self._write('01-intro/README.md', '# Not synced\n')
+        self._write_unit(
+            '01-intro', '01-why.md', 'Why',
+            'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        )
+
+        # Module 2: keeps README.
+        self._write_module_yaml(
+            '02-basics', 'Basics',
+            'dddddddd-dddd-dddd-dddd-dddddddddddd',
+        )
+        self._write('02-basics/README.md', '# Basics README\n\nKeep me.\n')
+        self._write_unit(
+            '02-basics', '01-vars.md', 'Vars',
+            'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
+        )
+
+        sync_content_source(self.source, repo_dir=self.temp_dir)
+        m1 = Module.objects.get(slug='intro')
+        m2 = Module.objects.get(slug='basics')
+        m1_slugs = set(Unit.objects.filter(module=m1).values_list('slug', flat=True))
+        m2_slugs = set(Unit.objects.filter(module=m2).values_list('slug', flat=True))
+        self.assertNotIn('readme', m1_slugs)
+        self.assertIn('readme', m2_slugs)
+
+
+class CourseSyncIdempotencyTest(_CourseSyncFixtureBase):
+    """A second identical sync must not create or delete anything."""
+
+    def test_double_sync_is_idempotent(self):
+        self._write_root_course_yaml(
+            extras=(
+                'ignore:\n'
+                '  - AGENTS.md\n'
+                '  - "**/*.template.md"\n'
+            ),
+        )
+        self._write('README.md', '# Python Course\n\nOverview.\n')
+        self._write('AGENTS.md', '# Agents\nIgnored.\n')
+
+        self._write_module_yaml(
+            '01-intro', 'Intro',
+            'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        )
+        self._write('01-intro/README.md', '# Intro\n\nFirst unit.\n')
+        self._write_unit(
+            '01-intro', '01-why.md', 'Why',
+            'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        )
+        self._write(
+            '01-intro/01-why.template.md',
+            '---\ntitle: "Template"\n---\nT\n',
+        )
+
+        log1 = sync_content_source(self.source, repo_dir=self.temp_dir)
+        self.assertEqual(log1.errors, [])
+        created_first = log1.items_created
+
+        log2 = sync_content_source(self.source, repo_dir=self.temp_dir)
+        self.assertEqual(log2.errors, [])
+        # Second sync creates nothing new and deletes nothing.
+        self.assertEqual(log2.items_created, 0)
+        self.assertEqual(log2.items_deleted, 0)
+
+        # Sanity: the first sync created course (1) + module (1) + readme unit
+        # (1) + why unit (1) = 4.
+        self.assertEqual(created_first, 4)


### PR DESCRIPTION
## Summary
- Adds `ignore:` glob support in `course.yaml` so content repos can exclude files from course sync (e.g. `AGENTS.md`, `docs/**`, planning templates).
- Fixes README handling: a course's root `README.md` is no longer treated as a lesson.
- Closes #200.

## Validation
Tester approved:
- 26 new unit tests in `integrations/tests/test_course_ignore_readme.py`, all passing.
- python-course sync: 35 parse errors reduced to 0 after onboarding the `ignore:` block.
- aihero course re-synced with no regressions.
- 3 screenshots captured across Studio sync and course detail pages.

PM approved.

## Test plan
- [x] `uv run ruff check .` clean
- [x] `uv run python manage.py test --parallel` — 3735 tests passing
- [x] python-course content repo updated with matching `ignore:` block