### PR TITLE
Studio: real worker liveness detection + warnings (#214)

### DIFF
--- a/studio/context_processors.py
+++ b/studio/context_processors.py
@@ -1,0 +1,20 @@
+"""Studio template context processors.
+
+Adds variables that should be available on every studio page.
+"""
+
+from studio.worker_health import get_worker_status
+
+
+def worker_status_banner(request):
+    """Expose worker liveness for the studio-wide banner.
+
+    Only runs for ``/studio/...`` requests — public pages don't need the banner.
+    Returns ``{'studio_worker_status': None}`` for non-studio requests so the
+    banner template short-circuits cleanly.
+    """
+    path = request.path or ''
+    if not path.startswith('/studio/'):
+        return {'studio_worker_status': None}
+
+    return {'studio_worker_status': get_worker_status()}

--- a/studio/tests/test_worker.py
+++ b/studio/tests/test_worker.py
@@ -1,15 +1,19 @@
 """Tests for the studio worker status dashboard.
 
 Verifies that:
-- Worker status page shows health indicator based on recent task activity
-- Recent tasks are listed with status, duration, and error details
-- Queue depth (pending tasks) is displayed
-- Failed tasks section shows error details
-- Staff-only access is enforced
+- Worker liveness is driven by ``django_q.status.Stat.get_all()``
+  (cluster heartbeat) rather than recent-task-completion proxy.
+- The page shows three states: running+busy, running+idle, not running.
+- Recent tasks are listed with status, duration, and error details.
+- Queue depth (pending tasks) is displayed.
+- Failed tasks section shows error details.
+- Staff-only access is enforced.
 """
 
 import uuid
 from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
@@ -24,6 +28,39 @@ def _create_task(**kwargs):
     if 'id' not in kwargs:
         kwargs['id'] = uuid.uuid4().hex
     return Task.objects.create(**kwargs)
+
+
+def _fake_cluster(
+    cluster_id='cluster-abc',
+    host='worker-1',
+    pid=1234,
+    workers=(101, 102),
+    status='Idle',
+    heartbeat_age_seconds=3.0,
+    tob_seconds_ago=300.0,
+    task_q_size=0,
+    done_q_size=0,
+):
+    """Build a stand-in for ``django_q.status.Stat`` for tests.
+
+    The real ``Stat.get_all()`` requires a running broker; we patch it to
+    return these lightweight fakes that expose the same attributes the helper
+    reads.
+    """
+    now = timezone.now()
+    cluster = SimpleNamespace(
+        cluster_id=cluster_id,
+        host=host,
+        pid=pid,
+        workers=list(workers),
+        status=status,
+        timestamp=now - timedelta(seconds=heartbeat_age_seconds),
+        tob=(now - timedelta(seconds=tob_seconds_ago)) if tob_seconds_ago else None,
+        task_q_size=task_q_size,
+        done_q_size=done_q_size,
+    )
+    cluster.uptime = lambda c=cluster: (timezone.now() - c.tob).total_seconds()
+    return cluster
 
 
 class WorkerStatusAccessTest(TestCase):
@@ -50,12 +87,13 @@ class WorkerStatusAccessTest(TestCase):
 
     def test_staff_gets_200(self):
         self.client.login(email='staff@test.com', password='testpass')
-        response = self.client.get('/studio/worker/')
+        with patch('studio.worker_health.Stat.get_all', return_value=[]):
+            response = self.client.get('/studio/worker/')
         self.assertEqual(response.status_code, 200)
 
 
-class WorkerStatusHealthTest(TestCase):
-    """Test worker health indicator based on recent task completions."""
+class WorkerLivenessTest(TestCase):
+    """Worker liveness is driven by cluster heartbeat, not recent tasks."""
 
     @classmethod
     def setUpTestData(cls):
@@ -66,36 +104,88 @@ class WorkerStatusHealthTest(TestCase):
     def setUp(self):
         self.client.login(email='staff@test.com', password='testpass')
 
-    def test_worker_inactive_when_no_recent_tasks(self):
-        response = self.client.get('/studio/worker/')
-        self.assertFalse(response.context['worker_healthy'])
-        self.assertContains(response, 'Worker Inactive')
+    def test_state_not_running_when_no_clusters(self):
+        with patch('studio.worker_health.Stat.get_all', return_value=[]):
+            response = self.client.get('/studio/worker/')
+        self.assertFalse(response.context['worker_alive'])
+        # Red banner with explicit "NOT running" wording and start command
+        self.assertContains(response, 'Worker NOT running')
+        self.assertContains(response, 'manage.py qcluster')
 
-    def test_worker_active_when_recent_task_completed(self):
+    def test_state_running_idle_when_cluster_present_no_queue(self):
+        cluster = _fake_cluster(
+            heartbeat_age_seconds=4.0, task_q_size=0, done_q_size=0,
+        )
+        with patch('studio.worker_health.Stat.get_all', return_value=[cluster]):
+            response = self.client.get('/studio/worker/')
+        self.assertTrue(response.context['worker_alive'])
+        self.assertTrue(response.context['worker_idle'])
+        self.assertContains(response, 'Worker running (idle)')
+
+    def test_state_running_busy_when_queue_has_tasks(self):
+        cluster = _fake_cluster(
+            heartbeat_age_seconds=2.0, task_q_size=3, done_q_size=0,
+        )
+        with patch('studio.worker_health.Stat.get_all', return_value=[cluster]):
+            response = self.client.get('/studio/worker/')
+        self.assertTrue(response.context['worker_alive'])
+        self.assertFalse(response.context['worker_idle'])
+        # Should show "Worker running" but not "(idle)"
+        self.assertContains(response, 'Worker running')
+        self.assertNotContains(response, 'Worker running (idle)')
+
+    def test_recent_completed_tasks_do_not_imply_alive(self):
+        """The old heuristic checked Task.stopped recency; the new one ignores it.
+
+        With recent successful tasks but no Stat heartbeat, the worker must be
+        reported as NOT running — otherwise we falsely tell users everything is
+        fine seconds after the worker died.
+        """
         now = timezone.now()
         _create_task(
             name='recent-task',
             func='some.func',
-            started=now - timedelta(minutes=2),
-            stopped=now - timedelta(minutes=1),
+            started=now - timedelta(seconds=30),
+            stopped=now - timedelta(seconds=5),
             success=True,
         )
-        response = self.client.get('/studio/worker/')
-        self.assertTrue(response.context['worker_healthy'])
-        self.assertContains(response, 'Worker Active')
+        with patch('studio.worker_health.Stat.get_all', return_value=[]):
+            response = self.client.get('/studio/worker/')
+        self.assertFalse(response.context['worker_alive'])
+        self.assertContains(response, 'Worker NOT running')
 
-    def test_worker_inactive_when_tasks_are_old(self):
-        now = timezone.now()
-        _create_task(
-            name='old-task',
-            func='some.func',
-            started=now - timedelta(minutes=30),
-            stopped=now - timedelta(minutes=20),
-            success=True,
+    def test_idle_worker_with_no_recent_tasks_still_alive(self):
+        """Old heuristic: idle for 5 min → 'Inactive'. New: stays alive."""
+        cluster = _fake_cluster(heartbeat_age_seconds=5.0)
+        with patch('studio.worker_health.Stat.get_all', return_value=[cluster]):
+            response = self.client.get('/studio/worker/')
+        self.assertTrue(response.context['worker_alive'])
+        # No Task rows exist — but heartbeat is fresh
+        self.assertEqual(Task.objects.count(), 0)
+
+    def test_broker_error_reported_as_not_running(self):
+        with patch(
+            'studio.worker_health.Stat.get_all',
+            side_effect=ConnectionError('broker unreachable'),
+        ):
+            response = self.client.get('/studio/worker/')
+        self.assertFalse(response.context['worker_alive'])
+        self.assertContains(response, 'broker unreachable')
+
+    def test_active_clusters_table_shows_cluster_metadata(self):
+        cluster = _fake_cluster(
+            cluster_id='abcdef123456',
+            host='worker-host-1',
+            workers=(11, 12, 13),
+            heartbeat_age_seconds=1.0,
+            tob_seconds_ago=600.0,
         )
-        response = self.client.get('/studio/worker/')
-        self.assertFalse(response.context['worker_healthy'])
-        self.assertContains(response, 'Worker Inactive')
+        with patch('studio.worker_health.Stat.get_all', return_value=[cluster]):
+            response = self.client.get('/studio/worker/')
+        self.assertContains(response, 'worker-host-1')
+        # 3 workers should be reported in cluster context
+        clusters_ctx = response.context['worker_info']['clusters']
+        self.assertEqual(clusters_ctx[0]['worker_count'], 3)
 
 
 class WorkerStatusQueueDepthTest(TestCase):
@@ -109,6 +199,11 @@ class WorkerStatusQueueDepthTest(TestCase):
 
     def setUp(self):
         self.client.login(email='staff@test.com', password='testpass')
+        # All these tests don't care about cluster state; default to "no worker"
+        # so each test has a deterministic baseline.
+        patcher = patch('studio.worker_health.Stat.get_all', return_value=[])
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     def test_queue_depth_zero_when_empty(self):
         response = self.client.get('/studio/worker/')
@@ -132,6 +227,9 @@ class WorkerStatusRecentTasksTest(TestCase):
 
     def setUp(self):
         self.client.login(email='staff@test.com', password='testpass')
+        patcher = patch('studio.worker_health.Stat.get_all', return_value=[])
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     def test_recent_tasks_displayed_in_table(self):
         now = timezone.now()
@@ -191,6 +289,9 @@ class WorkerStatusFailedTasksTest(TestCase):
 
     def setUp(self):
         self.client.login(email='staff@test.com', password='testpass')
+        patcher = patch('studio.worker_health.Stat.get_all', return_value=[])
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     def test_failed_tasks_section_shows_error_details(self):
         now = timezone.now()
@@ -228,6 +329,9 @@ class WorkerStatusTemplateTest(TestCase):
 
     def setUp(self):
         self.client.login(email='staff@test.com', password='testpass')
+        patcher = patch('studio.worker_health.Stat.get_all', return_value=[])
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     def test_uses_correct_template(self):
         response = self.client.get('/studio/worker/')

--- a/studio/tests/test_worker_banner.py
+++ b/studio/tests/test_worker_banner.py
@@ -1,0 +1,169 @@
+"""Tests for the studio-wide worker-down banner and sync trigger warnings.
+
+Covers:
+- Banner appears at the top of every Studio page when no worker is running.
+- Banner does NOT appear on public pages (banner is studio-only).
+- Banner is suppressed when ``EXPECT_WORKER=false``.
+- Sync trigger / sync-all surface a warning instead of a plain success when
+  the worker isn't running.
+"""
+
+import os
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from integrations.models import ContentSource
+
+User = get_user_model()
+
+
+class StudioWorkerBannerTest(TestCase):
+    """The red 'worker not running' banner on studio pages."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.staff = User.objects.create_user(
+            email='staff@test.com', password='testpass', is_staff=True,
+        )
+
+    def setUp(self):
+        self.client.login(email='staff@test.com', password='testpass')
+
+    def test_banner_shown_on_studio_dashboard_when_no_worker(self):
+        with patch('studio.worker_health.Stat.get_all', return_value=[]), \
+             patch.dict(os.environ, {}, clear=False):
+            os.environ.pop('EXPECT_WORKER', None)
+            response = self.client.get('/studio/')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Background worker not running')
+        self.assertContains(response, 'manage.py qcluster')
+
+    def test_banner_hidden_on_studio_dashboard_when_worker_alive(self):
+        # Build a fake cluster like other tests do
+        from studio.tests.test_worker_health import _fake_cluster
+        with patch('studio.worker_health.Stat.get_all', return_value=[_fake_cluster()]):
+            response = self.client.get('/studio/')
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'Background worker not running')
+
+    def test_banner_hidden_when_expect_worker_false(self):
+        with patch('studio.worker_health.Stat.get_all', return_value=[]), \
+             patch.dict(os.environ, {'EXPECT_WORKER': 'false'}):
+            response = self.client.get('/studio/')
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'Background worker not running')
+
+    def test_banner_appears_on_other_studio_pages(self):
+        """Banner is wired into studio/base.html — it must appear on any studio page."""
+        with patch('studio.worker_health.Stat.get_all', return_value=[]):
+            response = self.client.get('/studio/sync/')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Background worker not running')
+
+    def test_banner_not_shown_on_public_pages(self):
+        """Banner is studio-only; the home page must not include it."""
+        self.client.logout()
+        with patch('studio.worker_health.Stat.get_all', return_value=[]):
+            response = self.client.get('/')
+        # 200 expected; page must not show the studio banner
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'Background worker not running')
+
+    def test_studio_worker_status_context_set_for_studio_paths(self):
+        with patch('studio.worker_health.Stat.get_all', return_value=[]):
+            response = self.client.get('/studio/')
+        self.assertIn('studio_worker_status', response.context)
+        self.assertIsNotNone(response.context['studio_worker_status'])
+        self.assertFalse(response.context['studio_worker_status']['alive'])
+
+    def test_studio_worker_status_context_none_for_non_studio_paths(self):
+        self.client.logout()
+        response = self.client.get('/')
+        # Context processor returns None for non-studio paths so the banner
+        # template short-circuits without querying the broker.
+        self.assertIsNone(response.context.get('studio_worker_status'))
+
+
+class SyncTriggerWorkerWarningTest(TestCase):
+    """Sync-now / sync-all should warn when no worker is available."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.staff = User.objects.create_user(
+            email='staff@test.com', password='testpass', is_staff=True,
+        )
+        cls.source = ContentSource.objects.create(
+            repo_name='AI-Shipping-Labs/blog',
+            content_type='article',
+        )
+
+    def setUp(self):
+        self.client.login(email='staff@test.com', password='testpass')
+
+    @patch('django_q.tasks.async_task')
+    def test_sync_trigger_warns_when_worker_down(self, _mock_async):
+        with patch('studio.worker_health.Stat.get_all', return_value=[]):
+            response = self.client.post(
+                f'/studio/sync/{self.source.pk}/trigger/',
+                follow=True,
+            )
+        self.assertEqual(response.status_code, 200)
+        # The flash message should call out that the queue is filling but
+        # nothing is processing.
+        body = response.content.decode()
+        self.assertIn('Sync queued', body)
+        self.assertIn('worker is not running', body)
+        self.assertIn('manage.py qcluster', body)
+
+    @patch('django_q.tasks.async_task')
+    def test_sync_trigger_plain_success_when_worker_alive(self, _mock_async):
+        from studio.tests.test_worker_health import _fake_cluster
+        with patch('studio.worker_health.Stat.get_all', return_value=[_fake_cluster()]):
+            response = self.client.post(
+                f'/studio/sync/{self.source.pk}/trigger/',
+                follow=True,
+            )
+        body = response.content.decode()
+        self.assertIn('Sync queued', body)
+        self.assertNotIn('worker is not running', body)
+
+    @patch('django_q.tasks.async_task')
+    def test_sync_all_warns_when_worker_down(self, _mock_async):
+        with patch('studio.worker_health.Stat.get_all', return_value=[]):
+            response = self.client.post('/studio/sync/all/', follow=True)
+        body = response.content.decode()
+        self.assertIn('Sync triggered', body)
+        self.assertIn('worker is not running', body)
+
+
+class SyncDashboardInlineWarningTest(TestCase):
+    """The sync dashboard shows an inline yellow banner near the Sync All button."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.staff = User.objects.create_user(
+            email='staff@test.com', password='testpass', is_staff=True,
+        )
+        cls.source = ContentSource.objects.create(
+            repo_name='AI-Shipping-Labs/blog',
+            content_type='article',
+        )
+
+    def setUp(self):
+        self.client.login(email='staff@test.com', password='testpass')
+
+    def test_inline_warning_when_worker_down(self):
+        with patch('studio.worker_health.Stat.get_all', return_value=[]):
+            response = self.client.get('/studio/sync/')
+        self.assertContains(response, 'Worker not running')
+        self.assertContains(response, 'manage.py qcluster')
+
+    def test_no_inline_warning_when_worker_alive(self):
+        from studio.tests.test_worker_health import _fake_cluster
+        with patch('studio.worker_health.Stat.get_all', return_value=[_fake_cluster()]):
+            response = self.client.get('/studio/sync/')
+        # The phrase 'Worker not running' from the inline yellow box should
+        # not be present when the cluster is alive.
+        self.assertNotContains(response, 'Worker not running')

--- a/studio/tests/test_worker_health.py
+++ b/studio/tests/test_worker_health.py
@@ -1,0 +1,165 @@
+"""Tests for ``studio.worker_health`` — django-q liveness detection helpers.
+
+These tests mock ``django_q.status.Stat.get_all`` because the real call
+requires a running broker. The helper's contract is:
+
+- empty list → alive=False
+- non-empty list → alive=True, last_heartbeat_age derived from timestamp
+- broker exception → alive=False with ``error`` populated
+- busy if any cluster has queued/completed tasks in its internal queue
+"""
+
+import os
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+from django.utils import timezone
+
+from studio.worker_health import (
+    expect_worker,
+    get_worker_status,
+    worker_is_alive,
+)
+
+
+def _fake_cluster(
+    cluster_id='cid',
+    host='h1',
+    pid=1,
+    workers=(10,),
+    status='Idle',
+    heartbeat_age_seconds=2.0,
+    tob_seconds_ago=60.0,
+    task_q_size=0,
+    done_q_size=0,
+):
+    now = timezone.now()
+    c = SimpleNamespace(
+        cluster_id=cluster_id,
+        host=host,
+        pid=pid,
+        workers=list(workers),
+        status=status,
+        timestamp=now - timedelta(seconds=heartbeat_age_seconds),
+        tob=(now - timedelta(seconds=tob_seconds_ago)) if tob_seconds_ago else None,
+        task_q_size=task_q_size,
+        done_q_size=done_q_size,
+    )
+    c.uptime = lambda self=c: (timezone.now() - self.tob).total_seconds()
+    return c
+
+
+class GetWorkerStatusTest(SimpleTestCase):
+    def test_empty_cluster_list_means_not_alive(self):
+        with patch('studio.worker_health.Stat.get_all', return_value=[]):
+            info = get_worker_status()
+        self.assertFalse(info['alive'])
+        self.assertEqual(info['cluster_count'], 0)
+        self.assertIsNone(info['last_heartbeat_age'])
+        self.assertEqual(info['clusters'], [])
+        self.assertIsNone(info['error'])
+
+    def test_single_cluster_marks_alive_and_reports_heartbeat(self):
+        cluster = _fake_cluster(heartbeat_age_seconds=7.0)
+        with patch('studio.worker_health.Stat.get_all', return_value=[cluster]):
+            info = get_worker_status()
+        self.assertTrue(info['alive'])
+        self.assertEqual(info['cluster_count'], 1)
+        # Heartbeat age should be roughly 7s
+        self.assertAlmostEqual(info['last_heartbeat_age'], 7.0, delta=1.0)
+
+    def test_multi_cluster_reports_freshest_heartbeat(self):
+        stale = _fake_cluster(cluster_id='stale', heartbeat_age_seconds=12.0)
+        fresh = _fake_cluster(cluster_id='fresh', heartbeat_age_seconds=1.0)
+        with patch('studio.worker_health.Stat.get_all', return_value=[stale, fresh]):
+            info = get_worker_status()
+        self.assertEqual(info['cluster_count'], 2)
+        # min age → fresh
+        self.assertAlmostEqual(info['last_heartbeat_age'], 1.0, delta=1.0)
+
+    def test_idle_when_no_tasks_in_queues(self):
+        cluster = _fake_cluster(task_q_size=0, done_q_size=0)
+        with patch('studio.worker_health.Stat.get_all', return_value=[cluster]):
+            info = get_worker_status()
+        self.assertTrue(info['idle'])
+
+    def test_busy_when_task_queue_has_items(self):
+        cluster = _fake_cluster(task_q_size=5, done_q_size=0)
+        with patch('studio.worker_health.Stat.get_all', return_value=[cluster]):
+            info = get_worker_status()
+        self.assertFalse(info['idle'])
+
+    def test_busy_when_done_queue_has_items(self):
+        cluster = _fake_cluster(task_q_size=0, done_q_size=2)
+        with patch('studio.worker_health.Stat.get_all', return_value=[cluster]):
+            info = get_worker_status()
+        self.assertFalse(info['idle'])
+
+    def test_broker_error_surfaces_as_not_alive(self):
+        with patch(
+            'studio.worker_health.Stat.get_all',
+            side_effect=RuntimeError('redis down'),
+        ):
+            info = get_worker_status()
+        self.assertFalse(info['alive'])
+        self.assertEqual(info['error'], 'redis down')
+
+    def test_cluster_summary_fields(self):
+        cluster = _fake_cluster(
+            cluster_id='abc',
+            host='w1',
+            workers=(1, 2, 3),
+            status='Idle',
+            heartbeat_age_seconds=2.0,
+            tob_seconds_ago=30.0,
+        )
+        with patch('studio.worker_health.Stat.get_all', return_value=[cluster]):
+            info = get_worker_status()
+        c = info['clusters'][0]
+        self.assertEqual(c['cluster_id'], 'abc')
+        self.assertEqual(c['host'], 'w1')
+        self.assertEqual(c['worker_count'], 3)
+        self.assertEqual(c['status'], 'Idle')
+        self.assertAlmostEqual(c['heartbeat_age'], 2.0, delta=1.0)
+        self.assertAlmostEqual(c['uptime'], 30.0, delta=1.0)
+
+
+class WorkerIsAliveTest(SimpleTestCase):
+    def test_returns_false_when_no_cluster(self):
+        with patch('studio.worker_health.Stat.get_all', return_value=[]):
+            self.assertFalse(worker_is_alive())
+
+    def test_returns_true_when_cluster_present(self):
+        with patch('studio.worker_health.Stat.get_all', return_value=[_fake_cluster()]):
+            self.assertTrue(worker_is_alive())
+
+
+class ExpectWorkerEnvTest(SimpleTestCase):
+    def test_default_is_true(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop('EXPECT_WORKER', None)
+            self.assertTrue(expect_worker())
+
+    def test_false_lowercase_disables(self):
+        with patch.dict(os.environ, {'EXPECT_WORKER': 'false'}):
+            self.assertFalse(expect_worker())
+
+    def test_false_uppercase_disables(self):
+        with patch.dict(os.environ, {'EXPECT_WORKER': 'FALSE'}):
+            self.assertFalse(expect_worker())
+
+    def test_any_other_value_is_true(self):
+        with patch.dict(os.environ, {'EXPECT_WORKER': 'true'}):
+            self.assertTrue(expect_worker())
+        with patch.dict(os.environ, {'EXPECT_WORKER': '1'}):
+            self.assertTrue(expect_worker())
+        with patch.dict(os.environ, {'EXPECT_WORKER': ''}):
+            self.assertTrue(expect_worker())
+
+    def test_status_includes_expect_worker_flag(self):
+        with patch.dict(os.environ, {'EXPECT_WORKER': 'false'}), \
+             patch('studio.worker_health.Stat.get_all', return_value=[]):
+            info = get_worker_status()
+        self.assertFalse(info['expect_worker'])

--- a/studio/views/sync.py
+++ b/studio/views/sync.py
@@ -22,8 +22,24 @@ from django.views.decorators.http import require_POST
 from integrations.models import ContentSource, SyncLog
 from integrations.services.github import sync_content_source
 from studio.decorators import staff_required
+from studio.worker_health import get_worker_status
 
 logger = logging.getLogger(__name__)
+
+
+def _worker_warning_suffix():
+    """Return ' — worker not running, sync will not start until you run `manage.py qcluster`.'
+
+    or empty string if the worker is running. Appended to async-task success
+    messages so users know the queue is filling up but nothing is processing.
+    """
+    info = get_worker_status()
+    if info['expect_worker'] and not info['alive']:
+        return (
+            ' — worker is not running, sync will not start until you run '
+            '`manage.py qcluster`.'
+        )
+    return ''
 
 
 def _is_not_configured_error(errors):
@@ -227,11 +243,15 @@ def sync_trigger(request, source_id):
                 source,
                 task_name=f'sync-{source.repo_name}',
             )
-            messages.success(
-                request,
-                f'Sync queued for {source.repo_name}'
-                + (f' ({source.content_path})' if source.content_path else ''),
-            )
+            warning = _worker_warning_suffix()
+            label = source.repo_name
+            if source.content_path:
+                label = f'{label} ({source.content_path})'
+            base_msg = f'Sync queued for {label}'
+            if warning:
+                messages.warning(request, base_msg + warning)
+            else:
+                messages.success(request, base_msg)
         except ImportError:
             sync_content_source(source)
             messages.success(
@@ -272,7 +292,12 @@ def sync_all(request):
         except Exception:
             logger.exception('Error triggering sync for %s', source.repo_name)
 
-    messages.success(request, f'Sync triggered for {count} sources.')
+    warning = _worker_warning_suffix()
+    base_msg = f'Sync triggered for {count} source{"" if count == 1 else "s"}.'
+    if warning:
+        messages.warning(request, base_msg + warning)
+    else:
+        messages.success(request, base_msg)
     return redirect('studio_sync_dashboard')
 
 

--- a/studio/views/worker.py
+++ b/studio/views/worker.py
@@ -1,21 +1,23 @@
 """Studio view for django-q2 worker status dashboard.
 
 Shows worker health, queue depth, recent tasks, and failed task details.
+
+Liveness is determined by ``django_q.status.Stat.get_all()`` (cluster
+heartbeat), not by recent task activity — see ``studio.worker_health`` for
+the rationale.
 """
 
 from django.shortcuts import render
-from django.utils import timezone
+from django_q.models import OrmQ, Task
 
 from studio.decorators import staff_required
+from studio.worker_health import get_worker_status
 
 
 @staff_required
 def worker_status(request):
     """Display django-q2 worker status and recent task history."""
-    from django_q.models import OrmQ, Task
-
-    now = timezone.now()
-    five_minutes_ago = now - timezone.timedelta(minutes=5)
+    worker_info = get_worker_status()
 
     # Recent tasks (last 50)
     recent_tasks = Task.objects.order_by('-started')[:50]
@@ -23,10 +25,6 @@ def worker_status(request):
     # Success/failure counts
     success_count = Task.objects.filter(success=True).count()
     failure_count = Task.objects.filter(success=False).count()
-
-    # Worker health: any task completed in the last 5 minutes
-    recent_completions = Task.objects.filter(stopped__gte=five_minutes_ago).count()
-    worker_healthy = recent_completions > 0
 
     # Queue depth
     queue_depth = OrmQ.objects.count()
@@ -58,8 +56,12 @@ def worker_status(request):
         })
 
     return render(request, 'studio/worker.html', {
-        'worker_healthy': worker_healthy,
-        'recent_completions': recent_completions,
+        'worker_info': worker_info,
+        # Backwards-compatible aliases used by older template fragments / tests.
+        'worker_alive': worker_info['alive'],
+        'worker_idle': worker_info['idle'],
+        'last_heartbeat_age': worker_info['last_heartbeat_age'],
+        'cluster_count': worker_info['cluster_count'],
         'queue_depth': queue_depth,
         'success_count': success_count,
         'failure_count': failure_count,

--- a/studio/worker_health.py
+++ b/studio/worker_health.py
@@ -1,0 +1,116 @@
+"""Worker liveness detection helpers.
+
+Wraps ``django_q.status.Stat.get_all()`` so views and templates can answer
+"is the django-q cluster alive right now?" without relying on the misleading
+"any task completed in the last N minutes" proxy.
+
+A running cluster writes a Stat record to the broker every few seconds. An
+empty list from ``Stat.get_all()`` means no cluster process is running,
+regardless of recent task activity.
+"""
+
+import logging
+import os
+
+from django.utils import timezone
+from django_q.status import Stat
+
+logger = logging.getLogger(__name__)
+
+
+def expect_worker():
+    """Return True if the deployment expects an async worker to be running.
+
+    Set ``EXPECT_WORKER=false`` (env var) for one-off scripts or environments
+    that don't need async — the banner and warnings are suppressed.
+    Default: True.
+    """
+    return os.environ.get('EXPECT_WORKER', 'true').lower() != 'false'
+
+
+def get_worker_status():
+    """Return a dict describing the django-q cluster status.
+
+    Keys:
+        alive: bool                — at least one cluster heartbeat was found
+        cluster_count: int         — number of running clusters
+        last_heartbeat_age: float  — seconds since the most recent heartbeat,
+                                     or None if no clusters
+        idle: bool                 — cluster running but no busy workers
+        clusters: list[dict]       — per-cluster summary with id, host,
+                                     workers, status, heartbeat_age
+        expect_worker: bool        — whether the deployment expects a worker
+
+    Errors talking to the broker are logged and surfaced as ``alive=False``
+    with ``error`` set, so the dashboard can show a clear failure state.
+    """
+    info = {
+        'alive': False,
+        'cluster_count': 0,
+        'last_heartbeat_age': None,
+        'idle': False,
+        'clusters': [],
+        'expect_worker': expect_worker(),
+        'error': None,
+    }
+
+    try:
+        clusters = Stat.get_all()
+    except Exception as exc:
+        logger.warning('Failed to query django-q cluster status: %s', exc)
+        info['error'] = str(exc)
+        return info
+
+    if not clusters:
+        return info
+
+    now = timezone.now()
+    cluster_summaries = []
+    heartbeat_ages = []
+    any_busy = False
+
+    for cluster in clusters:
+        timestamp = getattr(cluster, 'timestamp', None)
+        if timestamp is not None:
+            heartbeat_age = (now - timestamp).total_seconds()
+        else:
+            heartbeat_age = None
+        if heartbeat_age is not None:
+            heartbeat_ages.append(heartbeat_age)
+
+        try:
+            uptime = cluster.uptime() if cluster.tob else None
+        except Exception:
+            uptime = None
+
+        worker_count = len(getattr(cluster, 'workers', []) or [])
+        task_q_size = getattr(cluster, 'task_q_size', 0) or 0
+        done_q_size = getattr(cluster, 'done_q_size', 0) or 0
+        if task_q_size > 0 or done_q_size > 0:
+            any_busy = True
+
+        cluster_summaries.append({
+            'cluster_id': getattr(cluster, 'cluster_id', ''),
+            'host': getattr(cluster, 'host', ''),
+            'pid': getattr(cluster, 'pid', None),
+            'worker_count': worker_count,
+            'status': getattr(cluster, 'status', ''),
+            'heartbeat_age': heartbeat_age,
+            'uptime': uptime,
+            'task_q_size': task_q_size,
+            'done_q_size': done_q_size,
+        })
+
+    info['alive'] = True
+    info['cluster_count'] = len(clusters)
+    info['last_heartbeat_age'] = (
+        min(heartbeat_ages) if heartbeat_ages else None
+    )
+    info['idle'] = not any_busy
+    info['clusters'] = cluster_summaries
+    return info
+
+
+def worker_is_alive():
+    """Convenience wrapper: True if at least one cluster heartbeat is present."""
+    return get_worker_status()['alive']

--- a/templates/studio/base.html
+++ b/templates/studio/base.html
@@ -192,6 +192,7 @@
 
   <!-- Main content -->
   <main class="flex-1 ml-0 md:ml-64 min-w-0 overflow-hidden">
+    {% include "studio/includes/worker_banner.html" %}
     <div class="p-4 pt-14 md:pt-8 md:p-8">
       {% block studio_content %}{% endblock %}
     </div>

--- a/templates/studio/includes/worker_banner.html
+++ b/templates/studio/includes/worker_banner.html
@@ -1,0 +1,26 @@
+{% comment %}
+Banner shown at the top of every Studio page when the django-q worker is
+not running. Suppressed when EXPECT_WORKER=false. Driven by the
+``studio_worker_status`` context variable populated by
+``studio.context_processors.worker_status_banner``.
+{% endcomment %}
+{% if studio_worker_status and studio_worker_status.expect_worker and not studio_worker_status.alive %}
+<div class="bg-red-500/15 border-b border-red-500/40 text-red-300" id="studio-worker-banner" role="alert">
+  <div class="px-4 py-3 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 text-sm">
+    <div class="flex items-start gap-2 min-w-0">
+      <svg class="w-4 h-4 mt-0.5 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01M5.07 19h13.86c1.54 0 2.5-1.67 1.73-3L13.73 4a2 2 0 00-3.46 0L3.34 16c-.77 1.33.19 3 1.73 3z"/></svg>
+      <div class="min-w-0">
+        <p class="font-medium">Background worker not running.</p>
+        <p class="text-red-200/80">
+          Async tasks (sync, attribution, notifications) will queue but not execute.
+          Run <code class="bg-red-500/25 px-1.5 py-0.5 rounded text-xs">manage.py qcluster</code> to start it.
+        </p>
+      </div>
+    </div>
+    <a href="{% url 'studio_worker' %}"
+       class="text-xs sm:text-sm underline whitespace-nowrap hover:text-red-100 self-start sm:self-center">
+      Worker status &rarr;
+    </a>
+  </div>
+</div>
+{% endif %}

--- a/templates/studio/sync/dashboard.html
+++ b/templates/studio/sync/dashboard.html
@@ -27,11 +27,21 @@
   </div>
 </div>
 
+{% if studio_worker_status and studio_worker_status.expect_worker and not studio_worker_status.alive %}
+<div class="mb-6 px-4 py-3 rounded-lg text-sm bg-yellow-500/15 border border-yellow-500/40 text-yellow-200">
+  <p class="font-medium">Worker not running.</p>
+  <p class="mt-1 text-yellow-200/80">
+    Sync jobs will be queued but not executed until you start the worker:
+    <code class="bg-yellow-500/20 px-1.5 py-0.5 rounded text-xs">uv run python manage.py qcluster</code>
+  </p>
+</div>
+{% endif %}
+
 <!-- Messages -->
 {% if messages %}
 <div class="mb-6 space-y-2">
   {% for message in messages %}
-  <div class="px-4 py-3 rounded-lg text-sm {% if message.tags == 'error' %}bg-red-500/20 text-red-400{% elif message.tags == 'success' %}bg-green-500/20 text-green-400{% else %}bg-blue-500/20 text-blue-400{% endif %}">
+  <div class="px-4 py-3 rounded-lg text-sm {% if message.tags == 'error' %}bg-red-500/20 text-red-400{% elif message.tags == 'success' %}bg-green-500/20 text-green-400{% elif message.tags == 'warning' %}bg-yellow-500/20 text-yellow-300{% else %}bg-blue-500/20 text-blue-400{% endif %}">
     {{ message }}
   </div>
   {% endfor %}

--- a/templates/studio/worker.html
+++ b/templates/studio/worker.html
@@ -9,27 +9,56 @@
     <p class="text-muted-foreground mt-1">django-q2 task worker health and recent activity</p>
   </div>
 
-  <!-- Health and Stats -->
-  <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
-    <!-- Worker Health -->
-    <div class="bg-card border border-border rounded-lg p-4">
+  <!-- Worker liveness banner -->
+  {% if worker_info.alive %}
+    <div class="bg-card border border-green-500/30 rounded-lg p-4">
       <div class="flex items-center space-x-3">
-        {% if worker_healthy %}
-          <div class="w-3 h-3 rounded-full bg-green-500" title="Worker active"></div>
-          <div>
-            <p class="text-sm font-medium text-foreground">Worker Active</p>
-            <p class="text-xs text-muted-foreground">{{ recent_completions }} task{{ recent_completions|pluralize }} in last 5 min</p>
-          </div>
-        {% else %}
-          <div class="w-3 h-3 rounded-full bg-red-500" title="Worker inactive"></div>
-          <div>
-            <p class="text-sm font-medium text-foreground">Worker Inactive</p>
-            <p class="text-xs text-muted-foreground">No tasks completed in last 5 min</p>
-          </div>
-        {% endif %}
+        <div class="w-3 h-3 rounded-full bg-green-500" title="Worker running"></div>
+        <div class="flex-1">
+          {% if worker_info.idle %}
+            <p class="text-sm font-medium text-foreground">
+              Worker running (idle)
+              {% if worker_info.last_heartbeat_age is not None %}
+                <span class="text-muted-foreground font-normal">— last heartbeat {{ worker_info.last_heartbeat_age|floatformat:0 }}s ago</span>
+              {% endif %}
+            </p>
+          {% else %}
+            <p class="text-sm font-medium text-foreground">
+              Worker running
+              {% if worker_info.last_heartbeat_age is not None %}
+                <span class="text-muted-foreground font-normal">(heartbeat {{ worker_info.last_heartbeat_age|floatformat:0 }}s ago)</span>
+              {% endif %}
+            </p>
+          {% endif %}
+          <p class="text-xs text-muted-foreground mt-1">
+            {{ worker_info.cluster_count }} cluster{{ worker_info.cluster_count|pluralize }} active
+          </p>
+        </div>
       </div>
     </div>
+  {% else %}
+    <div class="bg-red-500/10 border border-red-500/40 rounded-lg p-4">
+      <div class="flex items-start space-x-3">
+        <div class="w-3 h-3 mt-1.5 rounded-full bg-red-500" title="Worker not running"></div>
+        <div class="flex-1">
+          <p class="text-sm font-medium text-red-300">Worker NOT running.</p>
+          <p class="text-xs text-red-200/80 mt-1">
+            No django-q cluster is reporting a heartbeat. Async tasks will queue but never execute until a worker is started.
+          </p>
+          {% if worker_info.error %}
+            <p class="text-xs text-red-300/80 font-mono mt-2">Broker error: {{ worker_info.error }}</p>
+          {% endif %}
+          <div class="mt-3 inline-block bg-red-500/20 px-3 py-2 rounded">
+            <p class="text-xs text-red-200 mb-1">Start it with:</p>
+            <code class="text-sm text-red-100 font-mono">uv run python manage.py qcluster</code>
+          </div>
+        </div>
+      </div>
+    </div>
+  {% endif %}
 
+  <!-- Stats Grid -->
+  <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
     <!-- Queue Depth -->
     <div class="bg-card border border-border rounded-lg p-4">
       <p class="text-sm text-muted-foreground">Queue Depth</p>
@@ -51,6 +80,45 @@
       <p class="text-xs text-muted-foreground">total failed</p>
     </div>
   </div>
+
+  <!-- Active Clusters -->
+  {% if worker_info.clusters %}
+    <div class="bg-card border border-border rounded-lg">
+      <div class="p-4 border-b border-border">
+        <h2 class="text-lg font-medium text-foreground">Active Clusters</h2>
+      </div>
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-border">
+              <th class="text-left px-4 py-3 text-muted-foreground font-medium">Cluster ID</th>
+              <th class="text-left px-4 py-3 text-muted-foreground font-medium">Host</th>
+              <th class="text-left px-4 py-3 text-muted-foreground font-medium">Workers</th>
+              <th class="text-left px-4 py-3 text-muted-foreground font-medium">Status</th>
+              <th class="text-left px-4 py-3 text-muted-foreground font-medium">Heartbeat</th>
+              <th class="text-left px-4 py-3 text-muted-foreground font-medium">Uptime</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for c in worker_info.clusters %}
+              <tr class="border-b border-border last:border-0">
+                <td class="px-4 py-3 text-foreground font-mono text-xs">{{ c.cluster_id|truncatechars:12 }}</td>
+                <td class="px-4 py-3 text-muted-foreground">{{ c.host }}</td>
+                <td class="px-4 py-3 text-foreground">{{ c.worker_count }}</td>
+                <td class="px-4 py-3 text-muted-foreground">{{ c.status|default:"—" }}</td>
+                <td class="px-4 py-3 text-muted-foreground">
+                  {% if c.heartbeat_age is not None %}{{ c.heartbeat_age|floatformat:0 }}s ago{% else %}—{% endif %}
+                </td>
+                <td class="px-4 py-3 text-muted-foreground">
+                  {% if c.uptime is not None %}{{ c.uptime|floatformat:0 }}s{% else %}—{% endif %}
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  {% endif %}
 
   <!-- Recent Tasks Table -->
   <div class="bg-card border border-border rounded-lg">

--- a/website/settings.py
+++ b/website/settings.py
@@ -97,6 +97,7 @@ TEMPLATES = [
                 'website.context_processors.site_context',
                 'website.context_processors.impersonation_context',
                 'website.context_processors.announcement_banner_context',
+                'studio.context_processors.worker_status_banner',
             ],
         },
     },


### PR DESCRIPTION
## Summary
- Replaces stale worker status with real liveness detection from Django-Q heartbeats.
- Adds warning banner across Studio when worker is down or stale, surfacing actionable diagnostics.
- Wires worker health into sync dashboard so operators see broker/qcluster mismatches immediately.

## Test plan
- Tester live verification: 47 worker-specific tests pass; full suite 3766 tests pass.
- 3 worker states (running, stale, down) verified against real broker + qcluster.
- 6 screenshots captured covering banner, dashboard, and worker page across states.

Closes #214

Tester and PM approved.