### PR TITLE
Clarify Plans API update workflow

### DIFF
--- a/skills/ai-shipping-labs-plans-api/README.md
+++ b/skills/ai-shipping-labs-plans-api/README.md
@@ -2,8 +2,14 @@
 
 This directory is a downloadable Codex skill for working with the AI Shipping Labs member Plans API.
 
-Use `SKILL.md` with a local agent to read a member's own sprint plans, toggle progress, and reshape a plan end to end: edit narrative fields and add, rename, reorder, move, or remove weeks, checkpoints, deliverables, next steps, resources, and week notes. The skill covers the plan data model, the read and write endpoints with payload shapes, and best practices for building and iterating a good plan.
+Use `SKILL.md` with a local agent to update a member's own sprint plan. It is focused on the practical workflow: keep the key local, identify the target plan, fetch current IDs, apply the smallest safe set of edits, sync progress, and verify the final state.
 
-The skill expects the member API key to come from the user or from a local environment variable such as `AI_SHIPPING_LABS_MEMBER_API_KEY`.
+For the full API endpoint surface and request shapes, use the member API docs:
+
+```text
+https://aishippinglabs.com/member-api/docs
+```
+
+The skill expects the member API key to come from the user, a local `.env` file, or the current process environment as `AI_SHIPPING_LABS_MEMBER_API_KEY`. Do not commit `.env`.
 
 PRs are welcome against `skills/ai-shipping-labs-plans-api/` in the website repository.

--- a/skills/ai-shipping-labs-plans-api/SKILL.md
+++ b/skills/ai-shipping-labs-plans-api/SKILL.md
@@ -1,190 +1,167 @@
 ---
 name: ai-shipping-labs-plans-api
-description: Build, read, and iterate a member's own AI Shipping Labs sprint plan through the member Plans API. Use when a member wants to list their plans, fetch one plan, download plan Markdown, toggle checkpoint / deliverable / next-step progress, or reshape a plan end to end (edit narrative fields; add, rename, reorder, move, or remove weeks, checkpoints, deliverables, next steps, resources, and week notes) through /member-api/v1 using a member-owned API key.
+description: Update a member's own AI Shipping Labs sprint plan through the member Plans API. Use when a member wants to list plans, fetch one plan, download Markdown, sync a Markdown plan back to the platform, toggle progress, or edit weeks, checkpoints, deliverables, next steps, resources, and week notes through /member-api/v1 using a member-owned API key.
 ---
 
 # AI Shipping Labs Plans API
 
-Use the member API only. The base URL is:
+Use this skill to update a member's own sprint plan on AI Shipping Labs.
+
+Base URL:
 
 ```text
 https://aishippinglabs.com/member-api/v1
 ```
 
-Authenticate every request with:
+Auth header:
 
 ```text
-Authorization: Token <asl_member_...>
+Authorization: Token <AI_SHIPPING_LABS_MEMBER_API_KEY>
 ```
 
-All requests and responses are JSON. The key belongs to one member and only ever reaches that member's own plans.
+All requests and responses are JSON. Use only `/member-api/v1`.
 
-## Key Handling
+When this skill mentions an endpoint such as `GET /plans`, execute it with `curl` against the base URL and include the auth header above. For writes, also send `Content-Type: application/json` and the JSON payload.
 
-- Ask the user for a member API key when no local key is available.
-- Prefer reading `AI_SHIPPING_LABS_MEMBER_API_KEY` from the local environment.
-- Never hard-code a key.
-- Never write a key into repo files, logs, issue comments, commits, or generated docs.
-- Never ask the user to commit or store a key in the repository.
+For the full endpoint surface and request shapes, read:
 
-## Scopes
-
-A key carries a set of scopes; new keys are created with all three by default.
-
-- `plans:read` - read the owner's plans.
-- `plans:write_progress` - toggle `done` on existing items via `PATCH .../progress`.
-- `plans:write` - edit plan content (narrative fields and every collection below).
-
-The scopes are checked independently. A content-editing request made with a key that lacks `plans:write` returns `401`.
-
-## Plan Data Model
-
-A plan is owned by one member for one sprint. Its shape:
-
-- Plan narrative fields: `title` (max 280), `goal` (max 280), `summary` (`current_situation`, `goal`, `main_gap`, `weekly_hours`, `why_this_plan`), `focus` (`main`, `supporting` list of strings), `accountability`, and `visibility` (`private` or `cohort`; `public` is reserved).
-- `weeks`: ordered weekly blocks. Each week has a `week_number` (positive, unique per plan), a `theme`, a `position`, at most one `note`, and a list of `checkpoints`.
-- `checkpoints`: bullets that belong to a week. Each has a `description`, a `position`, and a `done_at` timestamp (null until done). Move one to another week by setting its `week_id`.
-- `deliverables`, `next_steps`, `resources`: plan-level collections. Deliverables and next steps have a `description`, `position`, and `done_at`. Next steps also have a `kind` of `pre_sprint` (default) or `next_step`. Resources have a `title` (max 300), optional `url` (must be valid, max 600), `note`, and `position`.
-
-Identifiers: every row has an integer `id`. Ordering within a collection is by `position` ascending (ties break by id / week number), so reorder by setting `position`. There is no bulk-reorder endpoint yet.
-
-## Allowed Operations
-
-Read:
-
-- List plans: `GET /member-api/v1/plans`.
-- Fetch one plan: `GET /member-api/v1/plans/{plan_id}`.
-- Download Markdown: `GET /member-api/v1/plans/{plan_id}/markdown`.
-
-Toggle progress only (`plans:write_progress`):
-
-- `PATCH /member-api/v1/plans/{plan_id}/progress` sets `done` on existing checkpoints, deliverables, and next steps. It never creates, deletes, reorders, renames, moves, or edits descriptions.
-
-```json
-{
-  "checkpoints": [{"id": 123, "done": true}],
-  "deliverables": [{"id": 456, "done": false}],
-  "next_steps": [{"id": 789, "done": true}]
-}
+```text
+https://aishippinglabs.com/member-api/docs
 ```
 
-Edit plan content (`plans:write`):
+## Key Setup
 
-- Narrative: `PATCH /member-api/v1/plans/{plan_id}` - partial update of `title`, `goal`, `summary.*`, `focus.*`, `accountability`, `visibility`. Only supplied keys change; returns the full plan detail.
-- Weeks: `POST /member-api/v1/plans/{plan_id}/weeks`, `PATCH /member-api/v1/plans/{plan_id}/weeks/{week_id}`, `DELETE /member-api/v1/plans/{plan_id}/weeks/{week_id}` (delete cascades the week's checkpoints and note).
-- Checkpoints: `POST /member-api/v1/plans/{plan_id}/weeks/{week_id}/checkpoints`, `PATCH /member-api/v1/plans/{plan_id}/checkpoints/{checkpoint_id}` (supply `week_id` to move it to another week of the same plan), `DELETE /member-api/v1/plans/{plan_id}/checkpoints/{checkpoint_id}`.
-- Deliverables: `POST /member-api/v1/plans/{plan_id}/deliverables`, `PATCH /member-api/v1/plans/{plan_id}/deliverables/{deliverable_id}`, `DELETE /member-api/v1/plans/{plan_id}/deliverables/{deliverable_id}`.
-- Next steps: `POST /member-api/v1/plans/{plan_id}/next-steps`, `PATCH /member-api/v1/plans/{plan_id}/next-steps/{next_step_id}`, `DELETE /member-api/v1/plans/{plan_id}/next-steps/{next_step_id}`.
-- Resources: `POST /member-api/v1/plans/{plan_id}/resources`, `PATCH /member-api/v1/plans/{plan_id}/resources/{resource_id}`, `DELETE /member-api/v1/plans/{plan_id}/resources/{resource_id}`.
-- Week note: `PUT /member-api/v1/plans/{plan_id}/weeks/{week_id}/note` (upsert, `body` required, records the owner as author), `DELETE /member-api/v1/plans/{plan_id}/weeks/{week_id}/note`.
+Prefer a local `.env` file:
 
-Create payloads: a week needs `week_number`; a checkpoint / deliverable / next step needs `description`; a resource needs `title`; a week note needs `body`. `position` and `done` are optional on create.
-
-## Payload Shapes
-
-Edit narrative fields:
-
-```json
-{
-  "title": "Ship an eval harness",
-  "goal": "A working evaluation harness",
-  "summary": {"goal": "A reusable eval harness", "weekly_hours": "6h"},
-  "focus": {"main": "Evaluation", "supporting": ["Tracing", "CI"]},
-  "accountability": "Weekly demo",
-  "visibility": "cohort"
-}
+```dotenv
+AI_SHIPPING_LABS_MEMBER_API_KEY=asl_member_...
 ```
 
-Create a checkpoint (POST to a week):
+Rules:
 
-```json
-{"description": "Draft the eval rubric", "position": 0, "done": false}
+- Never commit `.env`.
+- Never hard-code a real key in scripts, docs, commits, issue comments, PRs, or logs.
+- If the user pastes a key in chat, move it to `.env` and do not repeat it back.
+- If you create `.env` in a git workspace, add `.env` to `.gitignore` first.
+- Load the key into the current process only for the API calls.
+
+Bash loader:
+
+```bash
+set -a
+source .env
+set +a
 ```
 
-Move a checkpoint to another week and mark it done (PATCH):
+## Fast Path: Update A Plan From Markdown
 
-```json
-{"week_id": 35, "done": true}
-```
+Use this when the user gives you a Markdown plan export and asks you to update the platform plan.
 
-Create a next step:
+### 1. Read the Markdown
 
-```json
-{"description": "Read the tracing docs", "kind": "pre_sprint"}
-```
+Extract:
 
-Upsert a week note:
+- title and goal
+- summary fields
+- focus bullets
+- weekly checkpoints and checkbox states
+- week notes
+- resources
+- deliverables
+- accountability
+- pre-sprint actions and next steps
 
-```json
-{"body": "Shipped the harness; blocked on flaky evals."}
-```
+Treat `[x]` as done and `[ ]` as not done.
 
-## Building A Good Plan
-
-- Structure weeks around themes that build on each other (for a 6-week sprint: discovery, build, harden, ship). Give each week a short, concrete `theme`.
-- Keep 2 to 5 checkpoints per week - small, verifiable, outcome-oriented ("Wire the eval harness to CI"), not vague ("work on evals").
-- Phrase deliverables as the tangible artifacts the sprint produces ("A reusable eval harness with 20 cases").
-- Use `next_steps` with `kind: pre_sprint` for setup the member does before the sprint starts, and `kind: next_step` for follow-ups after it ends.
-- Add resources for the links and references the member will actually open, with a short `note` on why each matters.
-- Set `position` deliberately so the plan reads top to bottom in the order the member will work.
-
-## Iterate Loop
-
-Reshape a plan in a read-modify-write loop until it matches what the member wants:
-
-1. `GET /member-api/v1/plans/{plan_id}` to see the current structure and every `id`.
-2. Decide the smallest set of changes (edit narrative, add/rename/move/remove items).
-3. Apply them with the `plans:write` calls above. Each write is atomic, so a rejected request leaves the plan untouched.
-4. `GET` the plan again to confirm the result, then repeat.
-
-## Forbidden Surfaces
-
-Do not call `/api/`, `/studio/`, Django admin, CRM, staff APIs, operator APIs, or staff/operator documentation. Do not infer, request, or expose internal notes, CRM notes, onboarding answers, staff context, or other members' data. Only edit the plan the member asked you to work on.
-
-## Workflow
-
-1. Resolve the key from `AI_SHIPPING_LABS_MEMBER_API_KEY` or ask the user to provide it privately.
-2. Set `BASE_URL=https://aishippinglabs.com/member-api/v1`.
-3. Make the requested member API call with `Authorization: Token <key>`.
-4. Before editing items, fetch the plan so you know the current ids and order.
-5. Treat `401` as a missing, revoked, or under-scoped key; ask the user for a fresh key.
-6. Treat `404` as "this key owner cannot access that plan".
-7. Treat `422` as a validation error (bad field, duplicate `week_number`, `public` visibility, invalid `kind`, invalid `url`, or a child id from another plan); fix the payload and retry.
-
-## Examples
+### 2. Find the platform plan
 
 List plans:
 
-```bash
-curl -sS \
-  -H "Authorization: Token $AI_SHIPPING_LABS_MEMBER_API_KEY" \
-  https://aishippinglabs.com/member-api/v1/plans
+```text
+GET /plans
 ```
 
-Add a week, then a checkpoint in it:
+Pick the plan by sprint, member name, and title. If two plans could match, ask the user before editing.
 
-```bash
-curl -sS -X POST \
-  -H "Authorization: Token $AI_SHIPPING_LABS_MEMBER_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"week_number": 1, "theme": "Discovery"}' \
-  https://aishippinglabs.com/member-api/v1/plans/12/weeks
+### 3. Fetch the full plan before editing
 
-curl -sS -X POST \
-  -H "Authorization: Token $AI_SHIPPING_LABS_MEMBER_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"description": "Draft the eval rubric"}' \
-  https://aishippinglabs.com/member-api/v1/plans/12/weeks/34/checkpoints
+```text
+GET /plans/{plan_id}
 ```
 
-Download Markdown:
+You need the current IDs from this response. Existing weeks, checkpoints, deliverables, resources, next steps, and notes are updated by integer ID.
 
-```bash
-curl -sS \
-  -H "Authorization: Token $AI_SHIPPING_LABS_MEMBER_API_KEY" \
-  -o plan.md \
-  https://aishippinglabs.com/member-api/v1/plans/12/markdown
+### 4. Make the smallest safe set of changes
+
+Prefer updating existing items over deleting and recreating them. Preserve an ID when the item is conceptually the same.
+
+Typical order:
+
+1. Patch plan narrative fields.
+2. Patch week themes and week notes.
+3. Patch, move, create, or delete checkpoints.
+4. Patch deliverables, resources, and next steps.
+5. Sync done states with the progress endpoint.
+6. Fetch the plan again and verify.
+
+### 5. Apply the update
+
+Use the member API docs for exact request shapes, but keep this sequence:
+
+1. Patch top-level narrative fields first.
+2. Patch week themes and week notes.
+3. Patch existing checkpoints; create, move, or delete only when needed.
+4. Patch deliverables, resources, and next steps.
+5. Sync done states last through the progress endpoint.
+
+Important details:
+
+- Only send fields that should change.
+- Use `position` to set order.
+- Move a checkpoint by patching its `week_id`.
+- Use the week-note endpoint for Markdown `Week notes`.
+- Use the progress endpoint only for checkbox/done state.
+
+### 6. Verify and report
+
+Fetch the plan again:
+
+```text
+GET /plans/{plan_id}
 ```
+
+Check:
+
+- title, goal, visibility
+- progress counts
+- number of weeks and checkpoints per week
+- done states
+- week notes
+- deliverables, resources, and next steps in position order
+
+Tell the user exactly what changed and what was verified. Do not expose the key.
+
+## Practical Rules For Agents
+
+- Fetch before writing so you have IDs.
+- Do not guess the target plan if list results are ambiguous.
+- Use `position` for ordering.
+- Move a checkpoint by patching its `week_id`.
+- Use `PUT /weeks/{week_id}/note` to create or replace a week note.
+- Use `PATCH /progress` only for checkbox/done state.
+- Keep retries narrow. If a request fails, fix that payload and retry; do not rerun the whole update blindly.
+- Treat `401` as a missing, revoked, or under-scoped key.
+- Treat `404` as inaccessible or nonexistent for this key.
+- Treat `422` as a validation error in the payload.
+
+## Building A Good Plan
+
+- Keep 2 to 5 checkpoints per week.
+- Make checkpoints concrete and verifiable.
+- Phrase deliverables as tangible artifacts.
+- Add only resources the member will actually open.
+- Keep weekly themes short and concrete.
+- Put items in the order the member will work on them.
 
 ## Contributions
 


### PR DESCRIPTION
﻿## What changed

- Reworked the Plans API skill into a shorter, task-focused guide for updating member plans.
- Added a clear Markdown-to-platform update workflow: read the Markdown, identify the target plan, fetch IDs, apply the smallest set of edits, sync progress last, and verify.
- Moved detailed endpoint/request-shape guidance out of the skill and pointed agents/humans to `/member-api/docs` instead.
- Clarified local `.env` handling for member API keys.

## Why

The previous skill mixed workflow guidance, data-model details, scopes, endpoint reference, and examples. That made it harder for humans and agents to see the practical path for updating a plan.

## Validation

- Reviewed the resulting docs diff.
- Checked for accidental real member API keys in `skills/ai-shipping-labs-plans-api`.
- Confirmed `https://aishippinglabs.com/member-api/docs` resolves to the member docs sign-in flow.
